### PR TITLE
Add support for generic vector allocator when serializing

### DIFF
--- a/src/container/vector_serialize.h
+++ b/src/container/vector_serialize.h
@@ -9,28 +9,28 @@
 
 namespace serdes {
 
-template <typename Serializer, typename T>
-void serializeVectorMeta(Serializer& s, std::vector<T>& vec) {
+template <typename Serializer, typename T, typename VectorAllocator>
+void serializeVectorMeta(Serializer& s, std::vector<T, VectorAllocator>& vec) {
   SizeType vec_size = vec.size();
   s | vec_size;
   vec.resize(vec_size);
 }
 
-template <typename Serializer, typename T>
-void serialize(Serializer& s, std::vector<T>& vec) {
+template <typename Serializer, typename T, typename VectorAllocator>
+void serialize(Serializer& s, std::vector<T, VectorAllocator>& vec) {
   serializeVectorMeta(s, vec);
   serializeArray(s, &vec[0], vec.size());
 }
 
-template <typename Serializer, typename T>
-void parserdesVectorMeta(Serializer& s, std::vector<T>& vec) {
+template <typename Serializer, typename T, typename VectorAllocator>
+void parserdesVectorMeta(Serializer& s, std::vector<T, VectorAllocator>& vec) {
   SizeType vec_size = vec.size();
   s & vec_size;
   vec.resize(vec_size);
 }
 
-template <typename Serializer, typename T>
-void parserdes(Serializer& s, std::vector<T>& vec) {
+template <typename Serializer, typename T, typename VectorAllocator>
+void parserdes(Serializer& s, std::vector<T, VectorAllocator>& vec) {
   parserdesVectorMeta(s, vec);
   parserdesArray(s, &vec[0], vec.size());
 }


### PR DESCRIPTION
This works and has been tested with over-aligned vector allocators. Closes #20 