### PR TITLE
Feature 49 push and pop diagnostics

### DIFF
--- a/src/container/list_serialize.h
+++ b/src/container/list_serialize.h
@@ -16,11 +16,13 @@ inline void deserializeOrderedElems(
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size
 ) {
   for (typename ContainerT::size_type i = 0; i < size; i++) {
+    #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wunknown-pragmas"
     #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     ElmT elm;
     s | elm;
     cont.push_back(elm);
+    #pragma GCC diagnostic pop
   }
 }
 

--- a/src/container/map_serialize.h
+++ b/src/container/map_serialize.h
@@ -18,11 +18,13 @@ inline void deserializeEmplaceElems(
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size
 ) {
   for (typename ContainerT::size_type i = 0; i < size; i++) {
+    #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wunknown-pragmas"
     #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     ElmT elm;
     s | elm;
     cont.emplace(elm);
+    #pragma GCC diagnostic pop
   }
 }
 

--- a/src/container/view_traverse_manual.h
+++ b/src/container/view_traverse_manual.h
@@ -110,11 +110,13 @@ struct TraverseManual<SerializerT,ViewType,1> {
     using SizeType = typename ViewType::size_type;
     for (SizeType i = 0; i < v.extent(0); i++) {
       if (s.isUnpacking()) {
+        #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wunknown-pragmas"
         #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         BaseType val;
         s | val;
         v.operator()(i) = val;
+        #pragma GCC diagnostic pop
       } else {
         BaseType const& val = v.operator()(i);
         s | val;
@@ -131,11 +133,13 @@ struct TraverseManual<SerializerT,ViewType,2> {
     for (SizeType i = 0; i < v.extent(0); i++) {
       for (SizeType j = 0; j < v.extent(1); j++) {
         if (s.isUnpacking()) {
+          #pragma GCC diagnostic push
           #pragma GCC diagnostic ignored "-Wunknown-pragmas"
           #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
           BaseType val;
           s | val;
           v.operator()(i,j) = val;
+          #pragma GCC diagnostic pop
         } else {
           BaseType const& val = v.operator()(i,j);
           s | val;
@@ -154,11 +158,13 @@ struct TraverseManual<SerializerT,ViewType,3> {
       for (SizeType j = 0; j < v.extent(1); j++) {
         for (SizeType k = 0; k < v.extent(2); k++) {
           if (s.isUnpacking()) {
+            #pragma GCC diagnostic push
             #pragma GCC diagnostic ignored "-Wunknown-pragmas"
             #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             BaseType val;
             s | val;
             v.operator()(i,j,k) = val;
+            #pragma GCC diagnostic pop
           } else {
             BaseType const& val = v.operator()(i,j,k);
             s | val;

--- a/src/serializers/packer.impl.h
+++ b/src/serializers/packer.impl.h
@@ -49,9 +49,11 @@ void PackerBuffer<BufferT>::contiguousBytes(
 
   SerialSizeType const len = size * num_elms;
   SerialByteType* spot = this->getSpotIncrement(len);
+  #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunknown-pragmas"
   #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   std::memcpy(spot, ptr, len);
+  #pragma GCC diagnostic pop
 }
 
 } /* end namespace serdes */


### PR DESCRIPTION
My original usage of #pragma GCC diagnostic ignored ... was incorrect.  We can use these revisions or scrap the #pragma GCC diagnostic ignored "-Wunknown-pragmas" and use -Wno-unknown-pragmas instead.