### PR TITLE
#73: Specify size_t for a loop over vector indices to quiet warning

### DIFF
--- a/src/container/vector_serialize.h
+++ b/src/container/vector_serialize.h
@@ -74,7 +74,7 @@ void serialize(Serializer& s, std::vector<bool, VectorAllocator>& vec) {
       s | elt;
     }
   } else {
-    for (auto i = 0; i < vec.size(); ++i) {
+    for (size_t i = 0; i < vec.size(); ++i) {
       bool elt;
       s | elt;
       vec[i] = elt;


### PR DESCRIPTION
Closes: #73 