### PR TITLE
123 add support for more types in memory footprinting mode

### DIFF
--- a/src/checkpoint/container/queue_serialize.h
+++ b/src/checkpoint/container/queue_serialize.h
@@ -48,17 +48,23 @@
 #include "checkpoint/common.h"
 
 #include <queue>
+#include <stack>
 
 namespace checkpoint {
 
 template <typename Serializer, typename T>
 void serialize(Serializer& s, const std::queue<T>& q) {
-  serializeQueue(s, q);
+  serializeQueueLikeContainer(s, q);
 }
 
 template <typename Serializer, typename T>
 void serialize(Serializer& s, const std::priority_queue<T>& q) {
-  serializeQueue(s, q);
+  serializeQueueLikeContainer(s, q);
+}
+
+template <typename Serializer, typename T>
+void serialize(Serializer& s, const std::stack<T>& stack) {
+  serializeQueueLikeContainer(s, stack);
 }
 
 template <
@@ -71,7 +77,7 @@ template <
     >::value
   >
 >
-void serializeQueue(SerializerT& s, const Q& q) {
+void serializeQueueLikeContainer(SerializerT& s, const Q& q) {
   s.countBytes(q);
   s.contiguousBytes(nullptr, sizeof(typename Q::value_type), q.size());
 }

--- a/src/checkpoint/container/raw_ptr_serialize.h
+++ b/src/checkpoint/container/raw_ptr_serialize.h
@@ -81,19 +81,8 @@ void serializeRawPtr(SerializerT& s, T* ptr) {
 }
 
 /**
- * \brief Serialize FILE pointer \c ptr
- *
- * Only footprinting mode is supported at the moment. Counts the pointer size
- * without following it.
- *
- * \param[in] serializer serializer to use
- * \param[in] ptr pointer to serialize
+ * Note: do not follow void pointer.
  */
-template <typename SerializerT>
-void serialize(SerializerT& s, FILE* ptr) {
-  serializeFilePtr(s, ptr);
-}
-
 template <
   typename SerializerT,
   typename = std::enable_if_t<
@@ -103,7 +92,24 @@ template <
     >::value
   >
 >
-void serializeFilePtr(SerializerT& s, FILE* ptr) {
+void serializeRawPtr(SerializerT& s, void* ptr) {
+  s.countBytes(ptr);
+}
+
+/**
+ * Note: do not follow FILE pointer as it might be an incomplete type on some
+ * platforms.
+ */
+template <
+  typename SerializerT,
+  typename = std::enable_if_t<
+    std::is_same<
+      SerializerT,
+      checkpoint::Footprinter
+    >::value
+  >
+>
+void serializeRawPtr(SerializerT& s, FILE* ptr) {
   s.countBytes(ptr);
 }
 

--- a/tests/unit/test_footprinter.cc
+++ b/tests/unit/test_footprinter.cc
@@ -328,6 +328,20 @@ TEST_F(TestFootprinter, test_set) {
   }
 }
 
+TEST_F(TestFootprinter, test_stack) {
+  {
+    std::stack<int> stack;
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    EXPECT_EQ(
+      checkpoint::getMemoryFootprint(stack),
+      sizeof(stack) + stack.size() * sizeof(stack.top())
+    );
+    EXPECT_EQ(stack.size(), std::size_t{3});
+  }
+}
+
 // does not account for small string optimisation
 TEST_F(TestFootprinter, test_string) {
   std::string s = "123456789";

--- a/tests/unit/test_footprinter.cc
+++ b/tests/unit/test_footprinter.cc
@@ -99,6 +99,15 @@ TEST_F(TestFootprinter, test_fundamental_types) {
   }
 
   {
+    int i = 3;
+    void* ptr = static_cast<void*>(&i);
+    EXPECT_EQ(
+      checkpoint::getMemoryFootprint(ptr),
+      sizeof(ptr)
+    );
+  }
+
+  {
     int *arr = new int[5];
     EXPECT_EQ(
       checkpoint::getMemoryFootprint(arr),


### PR DESCRIPTION
adding memory footprinting support for `vt` components (https://github.com/DARMA-tasking/vt/issues/1009)

fixes #123 