### PR TITLE
136: test: fix compilation warnings in unit tests

### DIFF
--- a/tests/unit/test_container.cc
+++ b/tests/unit/test_container.cc
@@ -136,21 +136,21 @@ using ContUnorderedTypes = ::testing::Types<
 
 REGISTER_TYPED_TEST_CASE_P(TestContainer, test_single_ordered_container);
 
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int, TestContainer, ContOrderedTypes<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int16_t, TestContainer, ContOrderedTypes<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int32_t, TestContainer, ContOrderedTypes<int32_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int64_t, TestContainer, ContOrderedTypes<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_double, TestContainer, ContOrderedTypes<double>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_float, TestContainer, ContOrderedTypes<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int, TestContainer, ContOrderedTypes<int>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int16_t, TestContainer, ContOrderedTypes<int16_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int32_t, TestContainer, ContOrderedTypes<int32_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int64_t, TestContainer, ContOrderedTypes<int64_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_double, TestContainer, ContOrderedTypes<double>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_float, TestContainer, ContOrderedTypes<float>,);
 
 REGISTER_TYPED_TEST_CASE_P(TestContainerUnordered, test_single_unordered_container);
 
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int, TestContainerUnordered, ContUnorderedTypes<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int16_t, TestContainerUnordered, ContUnorderedTypes<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int32_t, TestContainerUnordered, ContUnorderedTypes<int32_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_int64_t, TestContainerUnordered, ContUnorderedTypes<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_double, TestContainerUnordered, ContUnorderedTypes<double>);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_float, TestContainerUnordered, ContUnorderedTypes<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int, TestContainerUnordered, ContUnorderedTypes<int>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int16_t, TestContainerUnordered, ContUnorderedTypes<int16_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int32_t, TestContainerUnordered, ContUnorderedTypes<int32_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_int64_t, TestContainerUnordered, ContUnorderedTypes<int64_t>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_double, TestContainerUnordered, ContUnorderedTypes<double>,);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_float, TestContainerUnordered, ContUnorderedTypes<float>,);
 
 template <typename ContainerT>
 struct TestMultiContainer : TestHarness { };
@@ -232,27 +232,27 @@ using ContainerMultiTypesUnorderedDouble = ContainerMultiTypesUnordered<T, doubl
 REGISTER_TYPED_TEST_CASE_P(TestMultiContainer, test_multi_container);
 REGISTER_TYPED_TEST_CASE_P(TestMultiContainerUnordered, test_multi_container_unordered);
 
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int, TestMultiContainer, ContainerMultiTypes<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_double, TestMultiContainer, ContainerMultiTypes<double>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int64_t, TestMultiContainer, ContainerMultiTypes<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int16_t, TestMultiContainer, ContainerMultiTypes<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_float, TestMultiContainer, ContainerMultiTypes<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int, TestMultiContainer, ContainerMultiTypes<int>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_double, TestMultiContainer, ContainerMultiTypes<double>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int64_t, TestMultiContainer, ContainerMultiTypes<int64_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int16_t, TestMultiContainer, ContainerMultiTypes<int16_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_float, TestMultiContainer, ContainerMultiTypes<float>, );
 
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int, TestMultiContainer, ContainerMultiTypesDouble<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int64_t, TestMultiContainer, ContainerMultiTypesDouble<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int16_t, TestMultiContainer, ContainerMultiTypesDouble<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_float, TestMultiContainer, ContainerMultiTypesDouble<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int, TestMultiContainer, ContainerMultiTypesDouble<int>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int64_t, TestMultiContainer, ContainerMultiTypesDouble<int64_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int16_t, TestMultiContainer, ContainerMultiTypesDouble<int16_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_float, TestMultiContainer, ContainerMultiTypesDouble<float>, );
 
 
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_double, TestMultiContainerUnordered, ContainerMultiTypesUnordered<double>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int64_t, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int16_t, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_float, TestMultiContainerUnordered, ContainerMultiTypesUnordered<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_double, TestMultiContainerUnordered, ContainerMultiTypesUnordered<double>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int64_t, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int64_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_int16_t, TestMultiContainerUnordered, ContainerMultiTypesUnordered<int16_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMulti_float, TestMultiContainerUnordered, ContainerMultiTypesUnordered<float>, );
 
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int64_t, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int64_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int16_t, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int16_t>);
-INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_float, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<float>);
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int64_t, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int64_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_int16_t, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<int16_t>, );
+INSTANTIATE_TYPED_TEST_CASE_P(TestMultiDouble_float, TestMultiContainerUnordered, ContainerMultiTypesUnorderedDouble<float>, );
 
 }}} // end namespace checkpoint::tests::unit

--- a/tests/unit/test_kokkos_serialize_0d.cc
+++ b/tests/unit/test_kokkos_serialize_0d.cc
@@ -77,7 +77,7 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest0D, test_0d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_0d, KokkosViewTest0D, Test0DTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(test_0d, KokkosViewTest0D, Test0DTypes, );
 
 #endif
 

--- a/tests/unit/test_kokkos_serialize_1d.cc
+++ b/tests/unit/test_kokkos_serialize_1d.cc
@@ -81,12 +81,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest1D, test_1d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L, KokkosViewTest1D, Test1DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R, KokkosViewTest1D, Test1DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S, KokkosViewTest1D, Test1DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L_C, KokkosViewTest1D, Test1DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R_C, KokkosViewTest1D, Test1DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S_C, KokkosViewTest1D, Test1DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L, KokkosViewTest1D, Test1DTypesLeft,);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R, KokkosViewTest1D, Test1DTypesRight,);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S, KokkosViewTest1D, Test1DTypesStride,);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L_C, KokkosViewTest1D, Test1DConstTypesLeft,);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R_C, KokkosViewTest1D, Test1DConstTypesRight,);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S_C, KokkosViewTest1D, Test1DConstTypesStride,);
 
 #endif
 
@@ -120,7 +120,7 @@ TYPED_TEST_P(KokkosDynamicViewTest, test_dynamic_1d) {
 REGISTER_TYPED_TEST_CASE_P(KokkosDynamicViewTest, test_dynamic_1d);
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_dynamic_view_1, KokkosDynamicViewTest, DynamicTestTypes
+  test_dynamic_view_1, KokkosDynamicViewTest, DynamicTestTypes,
 );
 
 

--- a/tests/unit/test_kokkos_serialize_2d.cc
+++ b/tests/unit/test_kokkos_serialize_2d.cc
@@ -82,12 +82,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest2D, test_2d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L,   KokkosViewTest2D, Test2DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R,   KokkosViewTest2D, Test2DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S,   KokkosViewTest2D, Test2DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L_C, KokkosViewTest2D, Test2DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R_C, KokkosViewTest2D, Test2DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S_C, KokkosViewTest2D, Test2DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L,   KokkosViewTest2D, Test2DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R,   KokkosViewTest2D, Test2DTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S,   KokkosViewTest2D, Test2DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L_C, KokkosViewTest2D, Test2DConstTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R_C, KokkosViewTest2D, Test2DConstTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S_C, KokkosViewTest2D, Test2DConstTypesStride, );
 
 #endif
 #endif

--- a/tests/unit/test_kokkos_serialize_3d.cc
+++ b/tests/unit/test_kokkos_serialize_3d.cc
@@ -82,12 +82,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3D, Test3DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3D, Test3DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3D, Test3DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3D, Test3DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3D, Test3DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3D, Test3DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3D, Test3DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3D, Test3DTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3D, Test3DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3D, Test3DConstTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3D, Test3DConstTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3D, Test3DConstTypesStride, );
 
 #endif
 

--- a/tests/unit/test_kokkos_serialize_dynrankview.cc
+++ b/tests/unit/test_kokkos_serialize_dynrankview.cc
@@ -117,9 +117,9 @@ REGISTER_TYPED_TEST_CASE_P(KokkosDynRankViewTest3D, test_3d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_1, KokkosDynRankViewTest1D, DynRankViewTestTypes);
-INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_2, KokkosDynRankViewTest2D, DynRankViewTestTypes);
-INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_3, KokkosDynRankViewTest3D, DynRankViewTestTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_1, KokkosDynRankViewTest1D, DynRankViewTestTypes, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_2, KokkosDynRankViewTest2D, DynRankViewTestTypes, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_dynrank_3, KokkosDynRankViewTest3D, DynRankViewTestTypes, );
 
 #endif
 

--- a/tests/unit/test_reconstruct.cc
+++ b/tests/unit/test_reconstruct.cc
@@ -263,6 +263,6 @@ using ConstructTypes = ::testing::Types<
 >;
 
 REGISTER_TYPED_TEST_CASE_P(TestReconstruct, test_reconstruct_multi_type);
-INSTANTIATE_TYPED_TEST_CASE_P(Test_reconstruct, TestReconstruct, ConstructTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(Test_reconstruct, TestReconstruct, ConstructTypes, );
 
 }}} // end namespace checkpoint::tests::unit

--- a/tests/unit/test_serialize_file.cc
+++ b/tests/unit/test_serialize_file.cc
@@ -165,7 +165,7 @@ using ConstructTypes = ::testing::Types<
 REGISTER_TYPED_TEST_CASE_P(TestSerializeFile, test_serialize_file_multi);
 REGISTER_TYPED_TEST_CASE_P(TestSerializeFileInPlace, test_serialize_file_multi_in_place);
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_file, TestSerializeFile, ConstructTypes);
-INSTANTIATE_TYPED_TEST_CASE_P(test_file_in_place, TestSerializeFileInPlace, ConstructTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(test_file, TestSerializeFile, ConstructTypes, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_file_in_place, TestSerializeFileInPlace, ConstructTypes, );
 
 }}} // end namespace checkpoint::tests::unit

--- a/tests/unit/test_tagged_construct.cc
+++ b/tests/unit/test_tagged_construct.cc
@@ -134,6 +134,6 @@ using ConstructTypes = ::testing::Types<
 >;
 
 REGISTER_TYPED_TEST_CASE_P(TestTaggedConstruct, test_tagged_construct);
-INSTANTIATE_TYPED_TEST_CASE_P(test_tagged, TestTaggedConstruct, ConstructTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(test_tagged, TestTaggedConstruct, ConstructTypes, );
 
 }}} // end namespace checkpoint::tests::unit

--- a/tests/unit/test_virtual_serialize.cc
+++ b/tests/unit/test_virtual_serialize.cc
@@ -609,7 +609,7 @@ using ConstructTypes = ::testing::Types<
 REGISTER_TYPED_TEST_CASE_P(TestVirtualSerialize, test_virtual_serialize);
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_virtual_serialize_inst, TestVirtualSerialize, ConstructTypes
+  test_virtual_serialize_inst, TestVirtualSerialize, ConstructTypes,
 );
 
 }}} // end namespace checkpoint::tests::unit

--- a/tests/unit/tests_mpi/test_kokkos_serialize_0d_mpi.cc
+++ b/tests/unit/tests_mpi/test_kokkos_serialize_0d_mpi.cc
@@ -76,7 +76,7 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest0DMPI, test_0d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_0d, KokkosViewTest0DMPI, Test0DTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(test_0d, KokkosViewTest0DMPI, Test0DTypes, );
 
 #endif
 #endif

--- a/tests/unit/tests_mpi/test_kokkos_serialize_1d_mpi.cc
+++ b/tests/unit/tests_mpi/test_kokkos_serialize_1d_mpi.cc
@@ -82,12 +82,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest1DMPI, test_1d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L, KokkosViewTest1DMPI, Test1DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R, KokkosViewTest1DMPI, Test1DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S, KokkosViewTest1DMPI, Test1DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L_C, KokkosViewTest1DMPI, Test1DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R_C, KokkosViewTest1DMPI, Test1DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S_C, KokkosViewTest1DMPI, Test1DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L, KokkosViewTest1DMPI, Test1DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R, KokkosViewTest1DMPI, Test1DTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S, KokkosViewTest1DMPI, Test1DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_L_C, KokkosViewTest1DMPI, Test1DConstTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_R_C, KokkosViewTest1DMPI, Test1DConstTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_1d_S_C, KokkosViewTest1DMPI, Test1DConstTypesStride, );
 
 #endif
 
@@ -122,7 +122,7 @@ REGISTER_TYPED_TEST_CASE_P(KokkosDynamicViewTestMPI, test_dynamic_1d);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_dynamic_view_1, KokkosDynamicViewTestMPI, DynamicTestTypes
+  test_dynamic_view_1, KokkosDynamicViewTestMPI, DynamicTestTypes,
 );
 #endif
 

--- a/tests/unit/tests_mpi/test_kokkos_serialize_2d_mpi.cc
+++ b/tests/unit/tests_mpi/test_kokkos_serialize_2d_mpi.cc
@@ -80,12 +80,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest2DMPI, test_2d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L,   KokkosViewTest2DMPI, Test2DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R,   KokkosViewTest2DMPI, Test2DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S,   KokkosViewTest2DMPI, Test2DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L_C, KokkosViewTest2DMPI, Test2DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R_C, KokkosViewTest2DMPI, Test2DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S_C, KokkosViewTest2DMPI, Test2DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L,   KokkosViewTest2DMPI, Test2DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R,   KokkosViewTest2DMPI, Test2DTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S,   KokkosViewTest2DMPI, Test2DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_L_C, KokkosViewTest2DMPI, Test2DConstTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_R_C, KokkosViewTest2DMPI, Test2DConstTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_2d_S_C, KokkosViewTest2DMPI, Test2DConstTypesStride, );
 
 #endif
 #endif

--- a/tests/unit/tests_mpi/test_kokkos_serialize_3d_mpi.cc
+++ b/tests/unit/tests_mpi/test_kokkos_serialize_3d_mpi.cc
@@ -81,12 +81,12 @@ REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3DMPI, test_3d_any);
 
 #if DO_UNIT_TESTS_FOR_VIEW
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3DMPI, Test3DTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3DMPI, Test3DTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3DMPI, Test3DTypesStride);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3DMPI, Test3DConstTypesLeft);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3DMPI, Test3DConstTypesRight);
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3DMPI, Test3DConstTypesStride);
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3DMPI, Test3DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3DMPI, Test3DTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3DMPI, Test3DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3DMPI, Test3DConstTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3DMPI, Test3DConstTypesRight, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3DMPI, Test3DConstTypesStride, );
 
 #endif
 


### PR DESCRIPTION
Fixes #136 