### PR TITLE
158: fix std::vector serialization

### DIFF
--- a/src/checkpoint/container/vector_serialize.h
+++ b/src/checkpoint/container/vector_serialize.h
@@ -74,8 +74,10 @@ typename std::enable_if_t<
 template <typename Serializer, typename T, typename VectorAllocator>
 void serialize(Serializer& s, std::vector<T, VectorAllocator>& vec) {
   serializeVectorMeta(s, vec);
-  std::size_t num_elements = s.isFootprinting() ? vec.capacity() : vec.size();
-  dispatch::serializeArray(s, &vec[0], num_elements);
+  dispatch::serializeArray(s, vec.data(), vec.size());
+
+  // make sure to account for reserved space when footprinting
+  s.addBytes(sizeof(T) * (vec.capacity() - vec.size()));
 }
 
 template <typename Serializer, typename VectorAllocator>

--- a/src/checkpoint/dispatch/dispatch.impl.h
+++ b/src/checkpoint/dispatch/dispatch.impl.h
@@ -122,7 +122,7 @@ T* Standard::construct(SerialByteType* mem) {
 
 template <typename Serializer, typename T>
 inline void serializeArray(Serializer& s, T* array, SerialSizeType const len) {
-  if (array) {
+  if (len > 0) {
     Traverse::with<T, Serializer>(*array, s, len);
   }
 }

--- a/src/checkpoint/dispatch/dispatch.impl.h
+++ b/src/checkpoint/dispatch/dispatch.impl.h
@@ -122,7 +122,9 @@ T* Standard::construct(SerialByteType* mem) {
 
 template <typename Serializer, typename T>
 inline void serializeArray(Serializer& s, T* array, SerialSizeType const len) {
-  Traverse::with<T, Serializer>(*array, s, len);
+  if (array) {
+    Traverse::with<T, Serializer>(*array, s, len);
+  }
 }
 
 template <typename T>

--- a/src/checkpoint/serializers/base_serializer.h
+++ b/src/checkpoint/serializers/base_serializer.h
@@ -84,6 +84,7 @@ struct Serializer {
 
   template<typename T>
   void countBytes(const T& t) {}
+  void addBytes(std::size_t s) {}
 
   template <typename SerializerT, typename T>
   void contiguousTyped(SerializerT& serdes, T* ptr, SerialSizeType num_elms) {

--- a/tests/unit/test_footprinter.cc
+++ b/tests/unit/test_footprinter.cc
@@ -518,9 +518,15 @@ TEST_F(TestFootprinter, test_vector) {
 
   {
     std::vector<TestDerived2> v;
-    EXPECT_EQ(
+    EXPECT_GE(
       checkpoint::getMemoryFootprint(v),
       sizeof(v)
+    );
+
+    v.reserve(3);
+    EXPECT_EQ(
+      checkpoint::getMemoryFootprint(v),
+      sizeof(v) + v.capacity() * sizeof(TestDerived2)
     );
   }
 }


### PR DESCRIPTION
fixes #158 
fixes #159 

- do not traverse spare memory past the last element of vector (but account for it when footprinting)
- use data() to guarantee valid pointer to underlying array (even for empty container)
- avoid dereferencing null pointers on dispatch
- add adequate unit test
