### PR TITLE
#163: build: correct messages when package not found

### DIFF
--- a/cmake/load_package.cmake
+++ b/cmake/load_package.cmake
@@ -49,9 +49,8 @@ macro(find_package_local pkg_name pkg_directory pkg_other_name)
 
     foreach(prefix ${prefix_args})
       set(potential_path ${pkg_directory}/${prefix})
-      set(${pkg_name}_DIR ${potential_path})
       # message("prefix: ${potential_path}")
-      if (EXISTS "${${pkg_name}_DIR}${pkg_prefix}")
+      if (EXISTS "${potential_path}")
         # message(STATUS "find_package_local: trying path: ${potential_path}")
 
         # Search locally only for package based on the user's supplied path; if


### PR DESCRIPTION
Fixes #163.

This prints the paths it actually checks, and doesn't break anything for the two use cases I tested.