### PR TITLE
162: preserve std::vector and std::unordered_map capacity

### DIFF
--- a/src/checkpoint/container/map_serialize.h
+++ b/src/checkpoint/container/map_serialize.h
@@ -86,6 +86,15 @@ inline typename std::enable_if_t<
 ) { }
 
 template <typename Serializer, typename ContainerT>
+inline void serializeBucketCount(Serializer& s, ContainerT& cont) {
+  if (not s.isFootprinting()) {
+    auto bucket_count = cont.bucket_count();
+    s | bucket_count;
+    cont.rehash(bucket_count);
+  }
+}
+
+template <typename Serializer, typename ContainerT>
 inline void serializeMapLikeContainer(Serializer& s, ContainerT& cont) {
   using ValueT = typename ContainerT::value_type;
 
@@ -120,11 +129,13 @@ inline void serialize(Serializer& s, std::multiset<T, Comp>& set) {
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_map<T, U, Hash, Eq>& map) {
+  serializeBucketCount(s, map);
   serializeMapLikeContainer(s, map);
 }
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_multimap<T, U, Hash, Eq>& map) {
+  serializeBucketCount(s, map);
   serializeMapLikeContainer(s, map);
 }
 

--- a/src/checkpoint/container/map_serialize.h
+++ b/src/checkpoint/container/map_serialize.h
@@ -85,13 +85,21 @@ inline typename std::enable_if_t<
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size
 ) { }
 
-template <typename Serializer, typename ContainerT>
-inline void serializeBucketCount(Serializer& s, ContainerT& cont) {
+template <typename SerializerT, typename ContainerT>
+inline void serializeUnorderedAssociativeContainer(
+  SerializerT& s, ContainerT& cont
+) {
   if (not s.isFootprinting()) {
+    auto max_load_factor = cont.max_load_factor();
+    s | max_load_factor;
+    cont.max_load_factor(max_load_factor);
+
     auto bucket_count = cont.bucket_count();
     s | bucket_count;
     cont.rehash(bucket_count);
   }
+
+  serializeMapLikeContainer(s, cont);
 }
 
 template <typename Serializer, typename ContainerT>
@@ -129,24 +137,22 @@ inline void serialize(Serializer& s, std::multiset<T, Comp>& set) {
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_map<T, U, Hash, Eq>& map) {
-  serializeBucketCount(s, map);
-  serializeMapLikeContainer(s, map);
+  serializeUnorderedAssociativeContainer(s, map);
 }
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_multimap<T, U, Hash, Eq>& map) {
-  serializeBucketCount(s, map);
-  serializeMapLikeContainer(s, map);
+  serializeUnorderedAssociativeContainer(s, map);
 }
 
 template <typename Serializer, typename T, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_set<T, Hash, Eq>& set) {
-  serializeMapLikeContainer(s, set);
+  serializeUnorderedAssociativeContainer(s, set);
 }
 
 template <typename Serializer, typename T, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_multiset<T, Hash, Eq>& set) {
-  serializeMapLikeContainer(s, set);
+  serializeUnorderedAssociativeContainer(s, set);
 }
 
 } /* end namespace checkpoint */

--- a/src/checkpoint/container/vector_serialize.h
+++ b/src/checkpoint/container/vector_serialize.h
@@ -57,6 +57,10 @@ typename std::enable_if_t<
   not std::is_same<SerializerT, checkpoint::Footprinter>::value,
   void
 > serializeVectorMeta(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
+  SerialSizeType vec_capacity = vec.capacity();
+  s | vec_capacity;
+  vec.reserve(vec_capacity);
+
   SerialSizeType vec_size = vec.size();
   s | vec_size;
   vec.resize(vec_size);
@@ -69,7 +73,6 @@ typename std::enable_if_t<
 > serializeVectorMeta(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
   s.countBytes(vec);
 }
-
 
 template <typename Serializer, typename T, typename VectorAllocator>
 void serialize(Serializer& s, std::vector<T, VectorAllocator>& vec) {

--- a/tests/unit/test_container.cc
+++ b/tests/unit/test_container.cc
@@ -97,6 +97,25 @@ static void testContainer(bool is_ordered, std::initializer_list<T> lst) {
   }
 }
 
+template <>
+void testContainer<std::vector<int>, int>(
+  bool /*is_ordered*/, std::initializer_list<int> lst
+) {
+  std::vector<int> c1{lst};
+  std::size_t const reserved_capacity = 1000;
+  c1.reserve(reserved_capacity);
+  auto ret = checkpoint::serialize(c1);
+
+  auto t1 = checkpoint::deserialize<std::vector<int>>(ret->getBuffer());
+
+  EXPECT_EQ(c1.size(), t1->size());
+  // capacity: reserve() can overallocate, so check for greater or equal
+  EXPECT_GE(t1->capacity(), reserved_capacity);
+  EXPECT_GE(t1->capacity(), c1.capacity());
+
+  testEqualityContainerOrdered(c1, *t1);
+}
+
 TYPED_TEST_P(TestContainer, test_single_ordered_container) {
   using namespace checkpoint;
 

--- a/tests/unit/test_traversal.cc
+++ b/tests/unit/test_traversal.cc
@@ -159,7 +159,14 @@ TEST_F(TestTraversal, test_traversal) {
 
   auto traverse = checkpoint::dispatch::Traverse::with<TestObject, TestTraverse>(t);
 
-  EXPECT_EQ(traverse.bytes_, std::size_t{10*4 + 10*8 + 4 + 4 + 100*4 + 8*3});
+  constexpr std::size_t si = sizeof(int);
+  constexpr std::size_t sd = sizeof(double);
+  constexpr std::size_t sf = sizeof(float);
+  constexpr std::size_t ss = sizeof(std::size_t);
+  EXPECT_EQ(
+    traverse.bytes_,
+    std::size_t{10*si + 10*sd + si + si + 100*sf + 2*3*ss}
+  );
 }
 
 TEST_F(TestTraversal, test_traversal_dispatcher) {


### PR DESCRIPTION
fixes #162 