### PR TITLE
182: std::unordered_map serializer increasing memory consumption and causing Intel ICEs

### DIFF
--- a/src/checkpoint/container/map_serialize.h
+++ b/src/checkpoint/container/map_serialize.h
@@ -85,25 +85,6 @@ inline typename std::enable_if_t<
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size
 ) { }
 
-template <typename SerializerT, typename ContainerT>
-inline void serializeUnorderedAssociativeContainer(
-  SerializerT& s, ContainerT& cont
-) {
-  if (not s.isFootprinting()) {
-    auto max_load_factor = cont.max_load_factor();
-    s | max_load_factor;
-    cont.max_load_factor(max_load_factor);
-
-    auto bucket_count = cont.bucket_count();
-    s | bucket_count;
-    if (s.isUnpacking() and bucket_count > cont.bucket_count()) {
-      cont.rehash(bucket_count);
-    }
-  }
-
-  serializeMapLikeContainer(s, cont);
-}
-
 template <typename Serializer, typename ContainerT>
 inline void serializeMapLikeContainer(Serializer& s, ContainerT& cont) {
   using ValueT = typename ContainerT::value_type;
@@ -139,22 +120,22 @@ inline void serialize(Serializer& s, std::multiset<T, Comp>& set) {
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_map<T, U, Hash, Eq>& map) {
-  serializeUnorderedAssociativeContainer(s, map);
+  serializeMapLikeContainer(s, map);
 }
 
 template <typename Serializer, typename T, typename U, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_multimap<T, U, Hash, Eq>& map) {
-  serializeUnorderedAssociativeContainer(s, map);
+  serializeMapLikeContainer(s, map);
 }
 
 template <typename Serializer, typename T, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_set<T, Hash, Eq>& set) {
-  serializeUnorderedAssociativeContainer(s, set);
+  serializeMapLikeContainer(s, set);
 }
 
 template <typename Serializer, typename T, typename Hash, typename Eq>
 inline void serialize(Serializer& s, std::unordered_multiset<T, Hash, Eq>& set) {
-  serializeUnorderedAssociativeContainer(s, set);
+  serializeMapLikeContainer(s, set);
 }
 
 } /* end namespace checkpoint */

--- a/tests/unit/test_container.cc
+++ b/tests/unit/test_container.cc
@@ -115,19 +115,11 @@ void testContainerOrdered<std::vector<int>, int>(
 template <typename ContainerT, typename T>
 static void testContainerUnordered(std::initializer_list<T> lst) {
   ContainerT c1{lst};
-  float const custom_max_load_factor = .75;
-  c1.max_load_factor(custom_max_load_factor);
-  std::size_t const custom_bucket_count = 1000;
-  c1.rehash(custom_bucket_count);
 
   auto ret = checkpoint::serialize(c1);
   auto t1 = checkpoint::deserialize<ContainerT>(ret->getBuffer());
 
   EXPECT_EQ(c1.size(), t1->size());
-  EXPECT_EQ(t1->max_load_factor(), custom_max_load_factor);
-  EXPECT_EQ(t1->max_load_factor(), c1.max_load_factor());
-  EXPECT_GE(t1->bucket_count(), custom_bucket_count);
-  EXPECT_GE(t1->bucket_count(), c1.bucket_count());
 
   testEqualityContainerUnordered(c1, *t1);
 }
@@ -215,19 +207,11 @@ static void testMultiContainerOrdered(std::initializer_list<Pair> lst) {
 template <typename ContainerT, typename Pair>
 static void testMultiContainerUnordered(std::initializer_list<Pair> lst) {
   ContainerT c1{lst};
-  float const custom_max_load_factor = .75;
-  c1.max_load_factor(custom_max_load_factor);
-  std::size_t const custom_bucket_count = 1000;
-  c1.rehash(custom_bucket_count);
 
   auto ret = checkpoint::serialize(c1);
   auto t1 = checkpoint::deserialize<ContainerT>(ret->getBuffer());
 
   EXPECT_EQ(c1.size(), t1->size());
-  EXPECT_EQ(t1->max_load_factor(), custom_max_load_factor);
-  EXPECT_EQ(t1->max_load_factor(), c1.max_load_factor());
-  EXPECT_GE(t1->bucket_count(), custom_bucket_count);
-  EXPECT_GE(t1->bucket_count(), c1.bucket_count());
 
   testEqualityContainerUnordered(c1, *t1);
 }


### PR DESCRIPTION
fixes #182 