### PR TITLE
197 Expediently handle serialization of Kokkos::View inacessible from host space

### DIFF
--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -228,7 +228,7 @@ inline void serialize(
   // accessible from HostSpace, so no mirroring and copying is
   // necessary right now
 #if 0
-  auto host_view = Kokkos::create_mirror_view(view);
+  auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
   if (s.isPacking()) {
     // Create and use an execution space to avoid a global Kokkos::fence()
     auto exec_space = Kokkos::HostSpace::execution_space{};
@@ -347,7 +347,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
   s | init;
 
   if (init) {
-    auto host_view = Kokkos::create_mirror_view(view);
+    auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
     if (s.isPacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
       auto exec_space = Kokkos::HostSpace::execution_space{};
@@ -484,7 +484,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   s | init;
 
   if (init) {
-    auto host_view = Kokkos::create_mirror_view(view);
+    auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
     if (s.isPacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
       auto exec_space = Kokkos::HostSpace::execution_space{};

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -224,9 +224,7 @@ inline void serialize(
 
   DEBUG_PRINT_CHECKPOINT(s, "label=%s: size=%zu\n", label.c_str(), view.size());
 
-  // The implementation of Kokkos DynamicView demands that it be
-  // accessible from HostSpace, so no mirroring and copying is
-  // necessary right now
+  // Kokkos::deep_copy between DynamicView instances is not yet implemented
 #if 0
   auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
   if (s.isPacking()) {

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -447,7 +447,10 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   if (init) {
     auto host_view = Kokkos::create_mirror_view(view);
     if (s.isPacking()) {
-      Kokkos::deep_copy(host_view, view);
+      // Create and use an execution space to avoid a global Kokkos::fence()
+      auto exec_space = Kokkos::HostSpace{};
+      Kokkos::deep_copy(exec_space, host_view, view);
+      exec_space.fence();
     }
 
     // Serialize the actual data owned by the Kokkos::View
@@ -473,7 +476,10 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
     }
 
     if (s.isUnpacking()) {
-      Kokkos::deep_copy(view, host_view);
+      // Create and use an execution space to avoid a global Kokkos::fence()
+      auto exec_space = Kokkos::HostSpace{};
+      Kokkos::deep_copy(exec_space, view, host_view);
+      exec_space.fence();
     }
   }
 }

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -227,7 +227,7 @@ inline void serialize(
   auto host_view = Kokkos::create_mirror_view(view);
   if (s.isPacking()) {
     // Create and use an execution space to avoid a global Kokkos::fence()
-    auto exec_space = Kokkos::HostSpace{};
+    auto exec_space = Kokkos::HostSpace::execution_space{};
     Kokkos::deep_copy(exec_space, host_view, view);
     exec_space.fence();
   }
@@ -252,7 +252,7 @@ inline void serialize(
 #endif
     if (s.isUnpacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
-      auto exec_space = Kokkos::HostSpace{};
+      auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, view, host_view);
       exec_space.fence();
     }
@@ -340,7 +340,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
     auto host_view = Kokkos::create_mirror_view(view);
     if (s.isPacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
-      auto exec_space = Kokkos::HostSpace{};
+      auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, host_view, view);
       exec_space.fence();
     }
@@ -375,7 +375,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
 
     if (s.isUnpacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
-      auto exec_space = Kokkos::HostSpace{};
+      auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, view, host_view);
       exec_space.fence();
     }
@@ -477,7 +477,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
     auto host_view = Kokkos::create_mirror_view(view);
     if (s.isPacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
-      auto exec_space = Kokkos::HostSpace{};
+      auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, host_view, view);
       exec_space.fence();
     }
@@ -506,7 +506,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
 
     if (s.isUnpacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
-      auto exec_space = Kokkos::HostSpace{};
+      auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, view, host_view);
       exec_space.fence();
     }

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -445,10 +445,15 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   s | init;
 
   if (init) {
+    auto host_view = Kokkos::create_mirror_view(view);
+    if (s.isPacking()) {
+      Kokkos::deep_copy(host_view, view);
+    }
+
     // Serialize the actual data owned by the Kokkos::View
     if (is_contig) {
       // Serialize the data directly out of the data buffer
-      dispatch::serializeArray(s, view.data(), num_elms);
+      dispatch::serializeArray(s, host_view.data(), num_elms);
     } else {
       // Serialize manually traversing the data with Kokkos::View::operator()(...)
 
@@ -461,10 +466,14 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
         s | elm;
       };
 
-      TraverseRecursive<ViewType,T,dims,decltype(fn)>::apply(view,fn);
+      TraverseRecursive<ViewType,T,dims,decltype(fn)>::apply(host_view,fn);
 #else
-      TraverseManual<SerializerT,ViewType,rank_val>::apply(s,view);
+      TraverseManual<SerializerT,ViewType,rank_val>::apply(s,host_view);
 #endif
+    }
+
+    if (s.isUnpacking()) {
+      Kokkos::deep_copy(view, host_view);
     }
   }
 }

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -403,7 +403,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   // get propagate to the View from the layout
   //
   // Note: enabling this option will *not* work with Kokkos::LayoutStride. It
-  // will fail to compile with aa static_assert: because LayoutStide is not
+  // will fail to compile with a static_assert: because LayoutStide is not
   // extent constructible: traits::array_layout::is_extent_constructible!
   //
   constexpr auto dyn_dims = CountDims<ViewType, T>::dynamic;

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -58,6 +58,12 @@
 #include <Kokkos_Serial.hpp>
 #include <Kokkos_DynRankView.hpp>
 
+#if KOKKOS_VERSION > 30699L
+#define CHECKPOINT_KOKKOS_WITHOUTINIT Kokkos::WithoutInitializing,
+#else
+#define CHECKPOINT_KOKKOS_WITHOUTINIT
+#endif
+
 #if KOKKOS_KERNELS_ENABLED
 #include <Kokkos_StaticCrsGraph.hpp>
 #include <KokkosSparse_CrsMatrix.hpp>
@@ -238,7 +244,7 @@ inline void serialize(
 
   // Kokkos::deep_copy between DynamicView instances is not yet implemented
 #if 0
-  auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
+  auto host_view = Kokkos::create_mirror_view(CHECKPOINT_KOKKOS_WITHOUTINIT view);
   if (s.isPacking()) {
     deepCopyWithLocalFence(host_view, view);
   }
@@ -351,7 +357,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
   s | init;
 
   if (init) {
-    auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
+    auto host_view = Kokkos::create_mirror_view(CHECKPOINT_KOKKOS_WITHOUTINIT view);
     using HostViewType = decltype(host_view);
 
     if (s.isPacking()) {

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -224,6 +224,10 @@ inline void serialize(
 
   DEBUG_PRINT_CHECKPOINT(s, "label=%s: size=%zu\n", label.c_str(), view.size());
 
+  // The implementation of Kokkos DynamicView demands that it be
+  // accessible from HostSpace, so no mirroring and copying is
+  // necessary right now
+#if 0
   auto host_view = Kokkos::create_mirror_view(view);
   if (s.isPacking()) {
     // Create and use an execution space to avoid a global Kokkos::fence()
@@ -231,6 +235,9 @@ inline void serialize(
     Kokkos::deep_copy(exec_space, host_view, view);
     exec_space.fence();
   }
+#else
+  auto host_view = view;
+#endif
 
   // Serialize the Kokkos::DynamicView data manually by traversing with
   // DynamicView::operator()(...).
@@ -250,12 +257,15 @@ inline void serialize(
 #else
     TraverseManual<SerializerT,ViewType,1>::apply(s, host_view);
 #endif
+
+#if 0
     if (s.isUnpacking()) {
       // Create and use an execution space to avoid a global Kokkos::fence()
       auto exec_space = Kokkos::HostSpace::execution_space{};
       Kokkos::deep_copy(exec_space, view, host_view);
       exec_space.fence();
     }
+#endif
 }
 
 template <typename SerializerT, typename T, typename... Args>

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -224,6 +224,14 @@ inline void serialize(
 
   DEBUG_PRINT_CHECKPOINT(s, "label=%s: size=%zu\n", label.c_str(), view.size());
 
+  auto host_view = Kokkos::create_mirror_view(view);
+  if (s.isPacking()) {
+    // Create and use an execution space to avoid a global Kokkos::fence()
+    auto exec_space = Kokkos::HostSpace{};
+    Kokkos::deep_copy(exec_space, host_view, view);
+    exec_space.fence();
+  }
+
   // Serialize the Kokkos::DynamicView data manually by traversing with
   // DynamicView::operator()(...).
   //
@@ -238,10 +246,16 @@ inline void serialize(
       s | elm;
     };
 
-    TraverseRecursive<ViewType,T,1,decltype(fn)>::apply(view,fn);
+    TraverseRecursive<ViewType,T,1,decltype(fn)>::apply(host_view, fn);
 #else
-    TraverseManual<SerializerT,ViewType,1>::apply(s,view);
+    TraverseManual<SerializerT,ViewType,1>::apply(s, host_view);
 #endif
+    if (s.isUnpacking()) {
+      // Create and use an execution space to avoid a global Kokkos::fence()
+      auto exec_space = Kokkos::HostSpace{};
+      Kokkos::deep_copy(exec_space, view, host_view);
+      exec_space.fence();
+    }
 }
 
 template <typename SerializerT, typename T, typename... Args>
@@ -323,25 +337,33 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
   s | init;
 
   if (init) {
+    auto host_view = Kokkos::create_mirror_view(view);
+    if (s.isPacking()) {
+      // Create and use an execution space to avoid a global Kokkos::fence()
+      auto exec_space = Kokkos::HostSpace{};
+      Kokkos::deep_copy(exec_space, host_view, view);
+      exec_space.fence();
+    }
+
     // Serialize the actual data owned by the Kokkos::View
     if (is_contig) {
       // Serialize the data directly out of the data buffer
-      dispatch::serializeArray(s, view.data(), num_elms);
+      dispatch::serializeArray(s, host_view.data(), num_elms);
     } else {
       if (dims == 1) {
-        TraverseManual<SerializerT,ViewType,1>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,1>::apply(s,host_view);
       } else if (dims == 2) {
-        TraverseManual<SerializerT,ViewType,2>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,2>::apply(s,host_view);
       } else if (dims == 3) {
-        TraverseManual<SerializerT,ViewType,3>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,3>::apply(s,host_view);
       } else if (dims == 4) {
-        TraverseManual<SerializerT,ViewType,4>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,4>::apply(s,host_view);
       } else if (dims == 5) {
-        TraverseManual<SerializerT,ViewType,5>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,5>::apply(s,host_view);
       } else if (dims == 6) {
-        TraverseManual<SerializerT,ViewType,6>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,6>::apply(s,host_view);
       } else if (dims == 7) {
-        TraverseManual<SerializerT,ViewType,7>::apply(s,view);
+        TraverseManual<SerializerT,ViewType,7>::apply(s,host_view);
       } else {
         checkpointAssert(
           false,
@@ -349,6 +371,13 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
           " for non-contiguous views"
         );
       }
+    }
+
+    if (s.isUnpacking()) {
+      // Create and use an execution space to avoid a global Kokkos::fence()
+      auto exec_space = Kokkos::HostSpace{};
+      Kokkos::deep_copy(exec_space, view, host_view);
+      exec_space.fence();
     }
   }
 }

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -530,7 +530,7 @@ inline void serialize_const(SerializerT& s, Kokkos::View<T,Args...>& view) {
   using ViewType = Kokkos::View<T,Args...>;
   using T_non_const = typename ViewType::traits::non_const_data_type;
   Kokkos::View<T_non_const,Args...> tmp_non_const(view.label(), view.layout());
-  if (s.isPacking() || s.isSizing()) {
+  if (s.isPacking()) {
     deepCopyWithLocalFence(tmp_non_const, view);
   }
   serialize_impl(s, tmp_non_const);

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -352,6 +352,8 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
 
   if (init) {
     auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
+    using HostViewType = decltype(host_view);
+
     if (s.isPacking()) {
       deepCopyWithLocalFence(host_view, view);
     }
@@ -362,19 +364,19 @@ inline void serialize_impl(SerializerT& s, Kokkos::DynRankView<T,Args...>& view)
       dispatch::serializeArray(s, host_view.data(), num_elms);
     } else {
       if (dims == 1) {
-        TraverseManual<SerializerT,ViewType,1>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,1>::apply(s,host_view);
       } else if (dims == 2) {
-        TraverseManual<SerializerT,ViewType,2>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,2>::apply(s,host_view);
       } else if (dims == 3) {
-        TraverseManual<SerializerT,ViewType,3>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,3>::apply(s,host_view);
       } else if (dims == 4) {
-        TraverseManual<SerializerT,ViewType,4>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,4>::apply(s,host_view);
       } else if (dims == 5) {
-        TraverseManual<SerializerT,ViewType,5>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,5>::apply(s,host_view);
       } else if (dims == 6) {
-        TraverseManual<SerializerT,ViewType,6>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,6>::apply(s,host_view);
       } else if (dims == 7) {
-        TraverseManual<SerializerT,ViewType,7>::apply(s,host_view);
+        TraverseManual<SerializerT,HostViewType,7>::apply(s,host_view);
       } else {
         checkpointAssert(
           false,
@@ -482,7 +484,9 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   s | init;
 
   if (init) {
-    auto host_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, view);
+    auto host_view = Kokkos::create_mirror_view(view);
+    using HostViewType = decltype(host_view);
+
     if (s.isPacking()) {
       deepCopyWithLocalFence(host_view, view);
     }
@@ -503,9 +507,9 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
         s | elm;
       };
 
-      TraverseRecursive<ViewType,T,dims,decltype(fn)>::apply(host_view,fn);
+      TraverseRecursive<HostViewType,T,dims,decltype(fn)>::apply(host_view,fn);
 #else
-      TraverseManual<SerializerT,ViewType,rank_val>::apply(s,host_view);
+      TraverseManual<SerializerT,HostViewType,rank_val>::apply(s,host_view);
 #endif
     }
 

--- a/tests/unit/test_kokkos_serialize_dynrankview.cc
+++ b/tests/unit/test_kokkos_serialize_dynrankview.cc
@@ -43,6 +43,7 @@
 #if KOKKOS_ENABLED_CHECKPOINT
 
 #include "test_commons.h"
+#include "test_harness.h"
 #include "test_kokkos_1d_commons.h"
 #include "test_kokkos_2d_commons.h"
 #include "test_kokkos_3d_commons.h"

--- a/tests/unit/test_kokkos_serialize_special.cc
+++ b/tests/unit/test_kokkos_serialize_special.cc
@@ -116,6 +116,35 @@ TEST_F(KokkosViewContentsTest, test_view_contents_2d_layout) {
   EXPECT_EQ(40, alias(1,1));
 }
 
+struct TestSpaceNamer {
+  static constexpr const char* get_name() { return "TestSpace"; }
+};
+
+using fake_memory_space = Kokkos::Experimental::LogicalMemorySpace<
+    Kokkos::HostSpace, Kokkos::DefaultHostExecutionSpace, TestSpaceNamer,
+    Kokkos::Experimental::LogicalSpaceSharesAccess::no_shared_access>;
+
+TEST_F(KokkosViewContentsTest, test_device_view_contents) {
+  // Create an inaccessible View
+  using LogicalViewType = Kokkos::View<int*, fake_memory_space>;
+  auto lv = LogicalViewType("lv", 1);
+
+  // Initialize a value
+  Kokkos::deep_copy(lv, 3);
+
+  auto ret = checkpoint::serialize<LogicalViewType>(lv);
+  auto out_view = checkpoint::deserialize<LogicalViewType>(ret->getBuffer());
+  auto const& out_view_ref = *out_view;
+
+  EXPECT_EQ(out_view_ref.extent(0), 1);
+
+  auto mirror = create_mirror_view(out_view_ref);
+  Kokkos::deep_copy(mirror, out_view_ref);
+
+  EXPECT_EQ(mirror(0), 3);
+}
+
+
 struct KokkosViewExtentTest : virtual testing::Test { };
 
 

--- a/tests/unit/test_kokkos_serialize_special.cc
+++ b/tests/unit/test_kokkos_serialize_special.cc
@@ -136,7 +136,7 @@ TEST_F(KokkosViewContentsTest, test_device_view_contents) {
   auto out_view = checkpoint::deserialize<LogicalViewType>(ret->getBuffer());
   auto const& out_view_ref = *out_view;
 
-  EXPECT_EQ(out_view_ref.extent(0), 1);
+  EXPECT_EQ(out_view_ref.extent(0), std::size_t(1));
 
   auto mirror = create_mirror_view(out_view_ref);
   Kokkos::deep_copy(mirror, out_view_ref);

--- a/tests/unit/test_kokkos_serialize_special.cc
+++ b/tests/unit/test_kokkos_serialize_special.cc
@@ -124,7 +124,7 @@ using fake_memory_space = Kokkos::Experimental::LogicalMemorySpace<
     Kokkos::HostSpace, Kokkos::DefaultHostExecutionSpace, TestSpaceNamer,
     Kokkos::Experimental::LogicalSpaceSharesAccess::no_shared_access>;
 
-TEST_F(KokkosViewContentsTest, test_device_view_contents) {
+TEST_F(KokkosViewContentsTest, test_logical_device_view_contents) {
   // Create an inaccessible View
   using LogicalViewType = Kokkos::View<int*, fake_memory_space>;
   auto lv = LogicalViewType("lv", 1);
@@ -144,6 +144,29 @@ TEST_F(KokkosViewContentsTest, test_device_view_contents) {
   EXPECT_EQ(mirror(0), 3);
 }
 
+#if defined(KOKKOS_ENABLE_CUDA)
+
+TEST_F(KokkosViewContentsTest, test_cuda_device_view_contents) {
+  // Create an inaccessible View
+  using LogicalViewType = Kokkos::View<int*, Kokkos::CudaSpace>;
+  auto lv = LogicalViewType("lv", 1);
+
+  // Initialize a value
+  Kokkos::deep_copy(lv, 3);
+
+  auto ret = checkpoint::serialize<LogicalViewType>(lv);
+  auto out_view = checkpoint::deserialize<LogicalViewType>(ret->getBuffer());
+  auto const& out_view_ref = *out_view;
+
+  EXPECT_EQ(out_view_ref.extent(0), std::size_t(1));
+
+  auto mirror = create_mirror_view(out_view_ref);
+  Kokkos::deep_copy(mirror, out_view_ref);
+
+  EXPECT_EQ(mirror(0), 3);
+}
+
+#endif
 
 struct KokkosViewExtentTest : virtual testing::Test { };
 


### PR DESCRIPTION
Allocate and operate on a full-sized host-accessible View as needed. The mirroring and `deep_copy` calls are no-ops if the view is already host accessible.

Depends on Kokkos 3.6 plus https://github.com/kokkos/kokkos/pull/4805, or Kokkos `develop`

Fixes #197