### PR TITLE
#237: Make sure that archives of Kokkos and Kokkos Kernels end up in different, known files

### DIFF
--- a/ci/deps/kokkos-kernels.sh
+++ b/ci/deps/kokkos-kernels.sh
@@ -16,9 +16,9 @@ build_dir=$2
 echo "${kokkos_version}"
 echo "${kokkos_zip_name}"
 
-wget "http://github.com/kokkos/kokkos-kernels/archive/${kokkos_zip_name}"
+wget -O kokkos-kernels.zip "http://github.com/kokkos/kokkos-kernels/archive/${kokkos_zip_name}"
 
-unzip "${kokkos_zip_name}"
+unzip kokkos-kernels.zip
 
 mkdir -p "${build_dir}"
 pushd "${build_dir}"

--- a/ci/deps/kokkos.sh
+++ b/ci/deps/kokkos.sh
@@ -16,9 +16,9 @@ openmp=$3
 echo "${kokkos_version}"
 echo "${kokkos_zip_name}"
 
-wget "http://github.com/kokkos/kokkos/archive/${kokkos_zip_name}"
+wget -O kokkos.zip "http://github.com/kokkos/kokkos/archive/${kokkos_zip_name}"
 
-unzip "${kokkos_zip_name}"
+unzip kokkos.zip
 
 mkdir -p "${build_dir}"
 pushd "${build_dir}"


### PR DESCRIPTION
Without this, the files are named, effectively, `${ref}.zip` when they're downloaded and saved. If one tries to use the same ref for both kokkos and kokkos-kernels, they collide, and one gets very funny behavior, because the contents of kokkos-kernels will be unpacked over the original kokkos.

Fixes: #237