### PR TITLE
Deserialize Kokkos::Views into existing allocation where possible

### DIFF
--- a/src/checkpoint/container/view_equality.h
+++ b/src/checkpoint/container/view_equality.h
@@ -280,8 +280,8 @@ struct ViewEquality {
    */
   template <typename EqT = detail::DefaultEQ>
   static bool compareExtents(ViewT const& v1, ViewU const& v2, EqT eq = {}) {
-    auto const ndims_v1 = CountDims<ViewT>::numDims(v1);
-    auto const ndims_v2 = CountDims<ViewU>::numDims(v2);
+    auto const ndims_v1 = CountDims<ViewT>::numDims;
+    auto const ndims_v2 = CountDims<ViewU>::numDims;
     CHECKPOINT_APPLY_OP(eq, ndims_v1, ndims_v2, "num dims equal");
     for (auto i = 0; i < ndims_v1; i++) {
       CHECKPOINT_APPLY_OP(eq, v1.extent(i), v2.extent(i), i);

--- a/src/checkpoint/container/view_equality.h
+++ b/src/checkpoint/container/view_equality.h
@@ -53,10 +53,6 @@
 #if KOKKOS_ENABLED_CHECKPOINT
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_View.hpp>
-#include <Kokkos_DynamicView.hpp>
-#include <Kokkos_Serial.hpp>
-#include <Kokkos_DynRankView.hpp>
 
 #include <array>
 #include <cassert>

--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -441,7 +441,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   }
 
   // Construct a view with the layout and use operator= to propagate out
-  if (s.isUnpacking()) {
+  if (s.isUnpacking() && (view.label() != label)) {
     view = constructView<ViewType>(label, std::make_tuple(layout));
   }
 #else
@@ -471,7 +471,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   s | extents_array;
 
   // Construct a view with the layout and use operator= to propagate out
-  if (s.isUnpacking()) {
+  if (s.isUnpacking() && (view.label() != label)) {
     view = constructView<ViewType>(label, extents_array);
   }
 #endif

--- a/src/checkpoint/container/view_traits_extract.h
+++ b/src/checkpoint/container/view_traits_extract.h
@@ -91,28 +91,21 @@ template <
 struct CountDims {
   using BaseT = typename std::decay<T>::type;
   static constexpr size_t dynamic = 0;
-  static int numDims(ViewType const& view) { return 0; }
+  static constexpr size_t numDims = 0;
 };
 
 template <typename ViewType, typename T>
 struct CountDims<ViewType, T*> {
   using BaseT = typename CountDims<ViewType,T>::BaseT;
   static constexpr size_t dynamic = CountDims<ViewType, T>::dynamic + 1;
-
-  static int numDims(ViewType const& view) {
-    auto const val = CountDims<ViewType, T>::numDims(view);
-    return val + 1;
-  }
+  static constexpr size_t numDims = CountDims<ViewType, T>::numDims + 1;
 };
 
 template <typename ViewType, typename T, size_t N>
 struct CountDims<ViewType, T[N]> {
   using BaseT = typename CountDims<ViewType,T>::BaseT;
   static constexpr size_t dynamic = CountDims<ViewType, T>::dynamic;
-  static int numDims(ViewType const& view) {
-    auto const val = CountDims<ViewType, T>::numDims(view);
-    return val + 1;
-  }
+  static constexpr size_t numDims = CountDims<ViewType, T>::numDims + 1;
 };
 
 } /* end namespace checkpoint */

--- a/tests/unit/test_commons.h
+++ b/tests/unit/test_commons.h
@@ -51,9 +51,6 @@
 #if KOKKOS_ENABLED_CHECKPOINT
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_View.hpp>
-#include <Kokkos_DynamicView.hpp>
-#include <Kokkos_Serial.hpp>
 
 #include <functional>
 

--- a/tests/unit/test_kokkos_1d_commons.h
+++ b/tests/unit/test_kokkos_1d_commons.h
@@ -45,8 +45,6 @@
 
 #include "test_commons.h"
 
-#include <Kokkos_DynRankView.hpp>
-
 template <typename ViewT, unsigned ndim>
 static void compareInner1d(ViewT const& k1, ViewT const& k2) {
   std::cout << "compareInner1d: " << k1.extent(0) << "," << k2.extent(0) << "\n";


### PR DESCRIPTION
When calling deserializeInPlace flavored APIs, if the view to be deserialized into already has the label and dimensions that it will need after deserializing, don't create a new view to copy data into.

At a base level, this is a minor optimization for the cases of pre-allocated/initialized views (skipping a malloc, and whatever Kokkos steps are involved in registering a new view). However, it also enables keeping shallow copies of the input view "intact" (ie they continue to be shallow copies as expected, rather than now pointing to an old view allocation).

This leads to slightly more complex semantics for deserializeInPlace, since the creation of a new view or not depends on the input view and the serialized information. However, in cases where a user does not know apriori the label/dimensions of a view it seems unlikely that they would have shallow copies scattered about already anyway. And depending on deserializeInPlace to generate a new view seems like an odd use-pattern that can be easily fixed by using a typical deserialize function and copying the new view reference. With this in mind, I don't expect this would be a breaking change for applications. 

The specific benefit to this is the ability to use Magistrate for recovering views from a copy of the view, which is used by Kokkos Resilience's ViewHooks strategy for automatically detecting views to checkpoint. Without this, a deserialize has to be followed by an unnecessary copy into the original view's allocation.