### PR TITLE
#263: Use either `Kokkos::` or `KokkosKernels::` `EXPORT` namespace for linking against Kokkos Kernels

### DIFF
--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -52,11 +52,11 @@ RUN ./gtest.sh 1.8.1 /pkgs
 ENV GTEST_ROOT=/pkgs/gtest/install
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 0
+RUN ./kokkos.sh 4.1.00 /pkgs 0
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 ENV MPI_EXTRA_FLAGS="" \

--- a/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
@@ -56,11 +56,11 @@ RUN ./gtest.sh 1.8.1 /pkgs
 ENV GTEST_ROOT=/pkgs/gtest/install
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 1
+RUN ./kokkos.sh 4.1.00 /pkgs 1
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 ENV MPI_EXTRA_FLAGS="" \

--- a/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
@@ -52,11 +52,11 @@ ENV CC=/opt/intel/install/bin/icc \
     CXX=/opt/intel/install/bin/icpc
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 1
+RUN ./kokkos.sh 4.1.00 /pkgs 1
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 ENV MPI_EXTRA_FLAGS="" \

--- a/ci/docker/ubuntu-20.04-gnu-docs.dockerfile
+++ b/ci/docker/ubuntu-20.04-gnu-docs.dockerfile
@@ -46,11 +46,11 @@ RUN ./gtest.sh 1.8.1 /pkgs
 ENV GTEST_ROOT=/pkgs/gtest/install
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 1
+RUN ./kokkos.sh 4.1.00 /pkgs 1
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 ENV MPI_EXTRA_FLAGS="" \

--- a/ci/docker/ubuntu-20.04-nvidia-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-nvidia-cpp.dockerfile
@@ -47,7 +47,7 @@ RUN ./gtest.sh 1.12.1 /pkgs
 ENV GTEST_ROOT=/pkgs/gtest/install
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 0
+RUN ./kokkos.sh 4.1.00 /pkgs 0
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 RUN mkdir -p /nvcc_wrapper/build && \
@@ -59,7 +59,7 @@ ENV MPI_EXTRA_FLAGS="" \
     CXX=nvcc_wrapper
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 FROM base as build

--- a/ci/docker/ubuntu-22.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-clang-cpp.dockerfile
@@ -52,11 +52,11 @@ RUN ./gtest.sh 1.8.1 /pkgs
 ENV GTEST_ROOT=/pkgs/gtest/install
 
 COPY ./ci/deps/kokkos.sh kokkos.sh
-RUN ./kokkos.sh 4.0.00 /pkgs 0
+RUN ./kokkos.sh 4.1.00 /pkgs 0
 ENV KOKKOS_ROOT=/pkgs/kokkos/install/lib
 
 COPY ./ci/deps/kokkos-kernels.sh kokkos-kernels.sh
-RUN ./kokkos-kernels.sh 4.0.00 /pkgs
+RUN ./kokkos-kernels.sh 4.1.00 /pkgs
 ENV KOKKOS_KERNELS_ROOT=/pkgs/kokkos-kernels/install/lib
 
 ENV MPI_EXTRA_FLAGS="" \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,15 @@ if (${kokkos_DIR_FOUND})
   if (KokkosKernels_DIR_FOUND)
     message(STATUS "Checkpoint: Kokkos kernels enabled")
     set(KERNELS 1)
-    target_link_libraries(${CHECKPOINT_LIBRARY} PUBLIC Kokkos::kokkoskernels)
+    # Kokkos Kernels historically installed its EXPORT targets in the Kokkos:: namespace, and several
+    # downstream packages import it as such, so it's not readily changed.
+    # Meanwhile, Trilinos installs it under the more consistent KokkosKernels:: namespace.
+    # Account for both possiblie routes of acquiring Kokkos Kernels here
+    if(TARGET KokkosKernels::kokkoskernels)
+      target_link_libraries(${CHECKPOINT_LIBRARY} PUBLIC KokkosKernels::kokkoskernels)
+    else()
+      target_link_libraries(${CHECKPOINT_LIBRARY} PUBLIC Kokkos::kokkoskernels)
+    endif()
   else()
     message(STATUS "Checkpoint: Kokkos kernels disabled")
     set(KERNELS 0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ if (${kokkos_DIR_FOUND})
     # Kokkos Kernels historically installed its EXPORT targets in the Kokkos:: namespace, and several
     # downstream packages import it as such, so it's not readily changed.
     # Meanwhile, Trilinos installs it under the more consistent KokkosKernels:: namespace.
-    # Account for both possiblie routes of acquiring Kokkos Kernels here
+    # Account for both possible routes of acquiring Kokkos Kernels here
     if(TARGET KokkosKernels::kokkoskernels)
       target_link_libraries(${CHECKPOINT_LIBRARY} PUBLIC KokkosKernels::kokkoskernels)
     else()


### PR DESCRIPTION
See https://github.com/kokkos/kokkos-kernels/issues/1749 for why both potential names are necessary to try.

Fixes #263