### PR TITLE
298 Drop manual `-fPIC` command line option applied across the board

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,6 @@ add_library(
 
 add_library(${CHECKPOINT_LIBRARY_NS} ALIAS ${CHECKPOINT_LIBRARY})
 
-target_compile_options(${CHECKPOINT_LIBRARY} PUBLIC "-fPIC")
 target_compile_features(${CHECKPOINT_LIBRARY} PUBLIC cxx_std_17)
 
 include(CMakePrintHelpers)


### PR DESCRIPTION
Fixes #298