### PR TITLE
#314: Kokkos: Update rank capitalization for Kokkos 4.1

### DIFF
--- a/src/checkpoint/container/view_serialize.h
+++ b/src/checkpoint/container/view_serialize.h
@@ -328,7 +328,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   using ViewType = Kokkos::View<T,Args...>;
   using ArrayLayoutType = typename ViewType::traits::array_layout;
 
-  static constexpr auto const rank_val = ViewType::Rank;
+  static constexpr auto const rank_val = ViewType::rank;
 
   checkpointAssert(
     ViewType::traits::is_managed,


### PR DESCRIPTION
Fixes #314

> Kokkos just released 4.1 and it was pushed into trilinos yesterday. EMPIRE sync of trilinos failed last night due to a deprecation warning (we are building with warnings as errors). I needed to make a minor change to vt to remove the deprecation warning. It is below. I will push this change to empire in a few minutes. Could you make the corresponding change to vt so that the next snapshot does not erase this change?
 
> Thanks!
> Roger
 
```diff --git a/TPL/checkpoint/src/checkpoint/container/view_serialize.h b/TPL/checkpoint/src/checkpoint/container/view_serialize.h
index eafc7b99..a753670e 100644
--- a/TPL/checkpoint/src/checkpoint/container/view_serialize.h
+++ b/TPL/checkpoint/src/checkpoint/container/view_serialize.h
@@ -328,7 +328,7 @@ inline void serialize_impl(SerializerT& s, Kokkos::View<T,Args...>& view) {
   using ViewType = Kokkos::View<T,Args...>;
   using ArrayLayoutType = typename ViewType::traits::array_layout;
 
-  static constexpr auto const rank_val = ViewType::Rank;
+  static constexpr auto const rank_val = ViewType::rank;
 
   checkpointAssert(
     ViewType::traits::is_managed,
```
 