### PR TITLE
274 add serializer for c++17 std::variant

### DIFF
--- a/ci/deps/cmake.sh
+++ b/ci/deps/cmake.sh
@@ -4,16 +4,33 @@ set -exo pipefail
 
 if test $# -lt 1
 then
-    echo "usage: ./$0 <cmake-version>"
+    echo "usage: ./$0 <cmake-version> <arch>"
     exit 1
 fi
 
 cmake_version=$1
-cmake_tar_name=cmake-${cmake_version}-Linux-x86_64.tar.gz
+arch=x86_64
+
+if test $# -gt 1
+then
+    arch=$2
+fi
+
+if test "${arch}" = "arm64v8"
+then
+    arch=aarch64
+fi
+
+if test "${arch}" = "amd64"
+then
+    arch=x86_64
+fi
+
+cmake_tar_name=cmake-${cmake_version}-linux-$arch.tar.gz
 
 echo "${cmake_version}"
 echo "${cmake_tar_name}"
 
-wget http://github.com/Kitware/CMake/releases/download/v"${cmake_version}"/"${cmake_tar_name}"
+wget http://github.com/Kitware/CMake/releases/download/v${cmake_version}/${cmake_tar_name}
 
-tar xzf "${cmake_tar_name}" --one-top-level=cmake --strip-components 1
+tar xzf ${cmake_tar_name} --one-top-level=cmake --strip-components 1

--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -38,8 +38,10 @@ RUN ln -s \
 ENV CC=${compiler} \
     CXX=clang++
 
+ARG arch
+
 COPY ./ci/deps/cmake.sh cmake.sh
-RUN ./cmake.sh 3.18.4
+RUN ./cmake.sh 3.23.4 ${arch}
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4

--- a/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
@@ -42,8 +42,10 @@ RUN ln -s \
 ENV CC=gcc \
     CXX=g++
 
+ARG arch
+
 COPY ./ci/deps/cmake.sh cmake.sh
-RUN ./cmake.sh 3.18.4
+RUN ./cmake.sh 3.23.4 ${arch}
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4

--- a/ci/docker/ubuntu-22.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-clang-cpp.dockerfile
@@ -38,8 +38,10 @@ RUN ln -s \
 ENV CC=${compiler} \
     CXX=clang++
 
+ARG arch
+
 COPY ./ci/deps/cmake.sh cmake.sh
-RUN ./cmake.sh 3.18.4
+RUN ./cmake.sh 3.23.4 ${arch}
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,21 @@ volumes:
   amd64-ubuntu-20.04-nvcc-11.2-cache:
   amd64-ubuntu-20.04-nvcc-11.4-cache:
   amd64-ubuntu-20.04-nvcc-12-cache:
+  arm64v8-ubuntu-18.04-clang-5.0-cache:
+  arm64v8-ubuntu-18.04-clang-6.0-cache:
+  arm64v8-ubuntu-18.04-clang-7-cache:
+  arm64v8-ubuntu-18.04-clang-8-cache:
+  arm64v8-ubuntu-18.04-clang-9-cache:
+  arm64v8-ubuntu-20.04-clang-10-cache:
+  arm64v8-ubuntu-18.04-gcc-8-cache:
+  arm64v8-ubuntu-20.04-gcc-8-cache:
+  arm64v8-ubuntu-20.04-gcc-9-cache:
+  arm64v8-ubuntu-20.04-gcc-10-cache:
+  arm64v8-ubuntu-18.04-icc-18-cache:
+  arm64v8-ubuntu-18.04-icc-19-cache:
+  arm64v8-ubuntu-20.04-nvcc-11.2-cache:
+  arm64v8-ubuntu-20.04-nvcc-11.4-cache:
+  arm64v8-ubuntu-20.04-nvcc-12-cache:
 
 # Define basic rules for ccache used across multiple services. The beauty of
 # docker compose with cached volumes is that similarily configured builds will

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,8 +128,7 @@ services:
     ulimits: &ulimits
       core: ${ULIMIT_CORE}
     environment:
-      <<: *ccache
-      <<: *checkpointopts
+      <<: [*ccache, *checkpointopts]
     volumes: &ubuntu-volumes
       - .:/checkpoint:delegated
       - ${CACHE}${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cache:/build:delegated
@@ -149,8 +148,7 @@ services:
       args: *default-args
     ulimits: *ulimits
     environment:
-      <<: *ccache
-      <<: *checkpointopts
+      <<: [*ccache, *checkpointopts]
     volumes: *ubuntu-volumes
     command: &build-against-vt-cpp-command >
       /bin/bash -c "
@@ -178,8 +176,7 @@ services:
       args: *default-args
     ulimits: *ulimits
     environment:
-      <<: *ccache
-      <<: *checkpointopts
+      <<: [*ccache, *checkpointopts]
     volumes: *ubuntu-volumes
 
   ##############################################################################

--- a/examples/checkpoint_example_traversal.cc
+++ b/examples/checkpoint_example_traversal.cc
@@ -80,8 +80,8 @@ private:
 }}} // end namespace magistrate::intrusive::examples
 
 /// Custom traverser for printing raw bytes
-struct PrintBytesTraverse : checkpoint::Serializer {
-  PrintBytesTraverse() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+struct PrintBytesTraverse : checkpoint::BaseSerializer {
+  PrintBytesTraverse() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 
   void contiguousBytes(void* ptr, std::size_t size, std::size_t num_elms) {
     printf("PrintBytesTraverse: size=%zu, num_elms=%zu\n", size, num_elms);
@@ -125,11 +125,11 @@ struct CustomDispatch<SerializerT, std::vector<U>> {
 };
 
 /// Custom traverser for printing typed ranges
-struct TypedTraverse : checkpoint::Serializer {
+struct TypedTraverse : checkpoint::BaseSerializer {
   template <typename U, typename V>
   using DispatcherType = CustomDispatch<U, V>;
 
-  TypedTraverse() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+  TypedTraverse() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 
   template <typename SerializerT, typename T>
   void contiguousTyped(SerializerT&, T*, std::size_t num_elms) {

--- a/examples/checkpoint_example_traversal_nonintrusive.cc
+++ b/examples/checkpoint_example_traversal_nonintrusive.cc
@@ -92,8 +92,8 @@ void serialize(Serializer& s, TestObject& obj) {
 }
 
 /// Custom traverser for printing raw bytes
-struct PrintBytesTraverse : checkpoint::Serializer {
-  PrintBytesTraverse() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+struct PrintBytesTraverse : checkpoint::BaseSerializer {
+  PrintBytesTraverse() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 
   void contiguousBytes(void* ptr, std::size_t size, std::size_t num_elms) {
     printf("PrintBytesTraverse: size=%zu, num_elms=%zu\n", size, num_elms);
@@ -137,11 +137,11 @@ struct CustomDispatch<SerializerT, std::vector<U>> {
 };
 
 /// Custom traverser for printing typed ranges
-struct TypedTraverse : checkpoint::Serializer {
+struct TypedTraverse : checkpoint::BaseSerializer {
   template <typename U, typename V>
   using DispatcherType = CustomDispatch<U, V>;
 
-  TypedTraverse() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+  TypedTraverse() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 
   template <typename SerializerT, typename T>
   void contiguousTyped(SerializerT&, T*, std::size_t num_elms) {

--- a/src/checkpoint/serializers/base_serializer.h
+++ b/src/checkpoint/serializers/base_serializer.h
@@ -68,11 +68,11 @@ struct BasicDispatcher;
 } /* end namespace dispatch */
 
 /**
- * \struct Serializer
+ * \struct BaseSerializer
  *
  * \brief General base class for serialiers
  */
-struct Serializer {
+struct BaseSerializer {
   using ModeType = eSerializationMode;
 
   template <typename SerializerT, typename T>
@@ -83,7 +83,7 @@ struct Serializer {
    *
    * \param[in] in_mode The serializer mode
    */
-  explicit Serializer(ModeType const& in_mode) : cur_mode_(in_mode) {}
+  explicit BaseSerializer(ModeType const& in_mode) : cur_mode_(in_mode) {}
 
   /**
    * \brief Get the serializer mode

--- a/src/checkpoint/serializers/footprinter.h
+++ b/src/checkpoint/serializers/footprinter.h
@@ -49,8 +49,8 @@
 
 namespace checkpoint {
 
-struct Footprinter : Serializer {
-  Footprinter() : Serializer(ModeType::Footprinting) { }
+struct Footprinter : BaseSerializer {
+  Footprinter() : BaseSerializer(ModeType::Footprinting) { }
 
   SerialSizeType getMemoryFootprint() const {
     return num_bytes_;

--- a/src/checkpoint/serializers/memory_serializer.h
+++ b/src/checkpoint/serializers/memory_serializer.h
@@ -49,13 +49,13 @@
 
 namespace checkpoint {
 
-struct MemorySerializer : Serializer {
+struct MemorySerializer : BaseSerializer {
   MemorySerializer(ModeType const& in_mode, SerialByteType* in_start)
-    : Serializer(in_mode), start_(in_start), cur_(in_start)
+    : BaseSerializer(in_mode), start_(in_start), cur_(in_start)
   { }
 
   explicit MemorySerializer(ModeType const& in_mode)
-    : Serializer(in_mode)
+    : BaseSerializer(in_mode)
   { }
 
   SerialByteType* getBuffer() const {

--- a/src/checkpoint/serializers/sizer.cc
+++ b/src/checkpoint/serializers/sizer.cc
@@ -47,7 +47,7 @@
 
 namespace checkpoint {
 
-Sizer::Sizer() : Serializer(ModeType::Sizing) { }
+Sizer::Sizer() : BaseSerializer(ModeType::Sizing) { }
 
 SerialSizeType Sizer::getSize() const {
   return num_bytes_;

--- a/src/checkpoint/serializers/sizer.h
+++ b/src/checkpoint/serializers/sizer.h
@@ -56,7 +56,7 @@ namespace checkpoint {
  * preprocessing pass before packing content so a properly sized buffer can be
  * allocated.
  */
-struct Sizer : Serializer {
+struct Sizer : BaseSerializer {
   /**
    * \internal \brief Construct a sizer
    */

--- a/src/checkpoint/traits/serializable_traits.h
+++ b/src/checkpoint/traits/serializable_traits.h
@@ -81,7 +81,7 @@ struct isByteCopyableImpl {
 template <typename T>
 struct isByteCopyable : detail::isByteCopyableImpl<T>::has_byteCopyTraitTrue {};
 
-template <typename T, typename S = checkpoint::Serializer>
+template <typename T, typename S = checkpoint::BaseSerializer>
 struct SerializableTraits {
   /**
    * Start with detection of "serialize" overloads, intrusive and non-intrusive.

--- a/src/checkpoint/traits/serializable_traits.h
+++ b/src/checkpoint/traits/serializable_traits.h
@@ -69,6 +69,11 @@ struct SerdesByteCopy {
   using isByteCopyable = std::true_type;
 };
 
+template <typename T>
+struct ByteCopyNonIntrusive {
+  using isByteCopyable = std::false_type;
+};
+
 namespace detail {
 template <typename T>
 struct isByteCopyableImpl {
@@ -150,7 +155,8 @@ struct SerializableTraits {
 
   // This defines what it means to be serializable without a serialize method
   static constexpr auto const is_bytecopyable =
-    has_byteCopyTraitTrue::value or has_isArith<T>::value;
+    has_byteCopyTraitTrue::value or has_isArith<T>::value or
+    ByteCopyNonIntrusive<T>::isByteCopyable::value;
 
   /**
    * Detect different types of re-constructibility: default constructors,

--- a/tests/unit/test_kokkos_3d_commons.h
+++ b/tests/unit/test_kokkos_3d_commons.h
@@ -191,6 +191,4 @@ TYPED_TEST_P(KokkosViewTest3D, test_3d_any) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
-
 #endif // TEST_KOKKOS_3D_COMMONS_H

--- a/tests/unit/test_kokkos_3d_commons.h
+++ b/tests/unit/test_kokkos_3d_commons.h
@@ -125,10 +125,7 @@ inline Kokkos::LayoutStride layout3d(lsType d1,lsType d2,lsType d3) {
 using Test3DTypes = std::tuple<
   int      ***, int      **[1], int      **[9],
   double   ***, double   **[1], double   **[9],
-  float    ***, float    **[1], float    **[9],
-  int32_t  ***, int32_t  **[1], int32_t  **[9],
   int64_t  ***, int64_t  **[1], int64_t  **[9],
-  unsigned ***, unsigned **[1], unsigned **[9],
   long     ***, long     **[1], long     **[9],
   long long***, long long**[1], long long**[9]
 >;
@@ -136,10 +133,7 @@ using Test3DTypes = std::tuple<
 using Test3DConstTypes = std::tuple<
   int       const ***, int       const **[1], int       const **[9],
   double    const ***, double    const **[1], double    const **[9],
-  float     const ***, float     const **[1], float     const **[9],
-  int32_t   const ***, int32_t   const **[1], int32_t   const **[9],
   int64_t   const ***, int64_t   const **[1], int64_t   const **[9],
-  unsigned  const ***, unsigned  const **[1], unsigned  const **[9],
   long      const ***, long      const **[1], long      const **[9],
   long long const ***, long long const **[1], long long const **[9]
 >;

--- a/tests/unit/test_kokkos_serialize_3d_left.cc
+++ b/tests/unit/test_kokkos_serialize_3d_left.cc
@@ -47,6 +47,7 @@
 #include "test_kokkos_3d_commons.h"
 
 #if DO_UNIT_TESTS_FOR_VIEW
+REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3D, Test3DTypesLeft, );
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3D, Test3DConstTypesLeft, );
 #endif

--- a/tests/unit/test_kokkos_serialize_3d_left.cc
+++ b/tests/unit/test_kokkos_serialize_3d_left.cc
@@ -1,0 +1,54 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                      test_kokkos_serialize_3d_left.cc
+//                 DARMA/checkpoint => Serialization Library
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#if KOKKOS_ENABLED_CHECKPOINT
+
+#include "test_harness.h"
+#include "test_commons.h"
+#include "test_kokkos_3d_commons.h"
+
+#if DO_UNIT_TESTS_FOR_VIEW
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3D, Test3DTypesLeft, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3D, Test3DConstTypesLeft, );
+#endif
+
+#endif

--- a/tests/unit/test_kokkos_serialize_3d_right.cc
+++ b/tests/unit/test_kokkos_serialize_3d_right.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                         test_kokkos_serialize_3d.cc
+//                     test_kokkos_serialize_3d_right.cc
 //                 DARMA/checkpoint => Serialization Library
 //
 // Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
@@ -46,48 +46,9 @@
 #include "test_commons.h"
 #include "test_kokkos_3d_commons.h"
 
-template <typename ParamT> struct KokkosViewTest3D : KokkosViewTest<ParamT> { };
-
-TYPED_TEST_CASE_P(KokkosViewTest3D);
-
-TYPED_TEST_P(KokkosViewTest3D, test_3d_any) {
-  using namespace checkpoint;
-
-  using LayoutType = typename std::tuple_element<1,TypeParam>::type;
-  using DataType   = typename std::tuple_element<0,TypeParam>::type;
-  using ViewType          = Kokkos::View<DataType, LayoutType>;
-  using NonConstT         = typename ViewType::traits::non_const_data_type;
-  using NonConstViewType  = Kokkos::View<NonConstT, LayoutType>;
-  using ConstT         = typename ViewType::traits::const_data_type;
-  using ConstViewType  = Kokkos::View<ConstT, LayoutType>;
-  static constexpr size_t const N = 5;
-  static constexpr size_t const M = 17;
-  static constexpr size_t const Q = 7;
-
-  LayoutType layout = layout3d<LayoutType>(N,M,Q);
-  NonConstViewType in_view("test-3D-some-string", layout);
-
-  init3d(in_view);
-
-  if (std::is_same<NonConstViewType, ViewType>::value) {
-    serializeAny<NonConstViewType>(in_view, &compare3d<NonConstViewType>);
-  } else {
-    ConstViewType const_in_view = in_view;
-    serializeAny<ConstViewType>(const_in_view, &compare3d<ConstViewType>);
-  }
-}
-
-REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
-
 #if DO_UNIT_TESTS_FOR_VIEW
-
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L, KokkosViewTest3D, Test3DTypesLeft, );
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3D, Test3DTypesRight, );
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3D, Test3DTypesStride, );
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_L_C, KokkosViewTest3D, Test3DConstTypesLeft, );
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3D, Test3DConstTypesRight, );
-INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3D, Test3DConstTypesStride, );
-
 #endif
 
 #endif

--- a/tests/unit/test_kokkos_serialize_3d_right.cc
+++ b/tests/unit/test_kokkos_serialize_3d_right.cc
@@ -47,6 +47,7 @@
 #include "test_kokkos_3d_commons.h"
 
 #if DO_UNIT_TESTS_FOR_VIEW
+REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R, KokkosViewTest3D, Test3DTypesRight, );
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_R_C, KokkosViewTest3D, Test3DConstTypesRight, );
 #endif

--- a/tests/unit/test_kokkos_serialize_3d_stride.cc
+++ b/tests/unit/test_kokkos_serialize_3d_stride.cc
@@ -1,0 +1,54 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                     test_kokkos_serialize_3d_stride.cc
+//                 DARMA/checkpoint => Serialization Library
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#if KOKKOS_ENABLED_CHECKPOINT
+
+#include "test_harness.h"
+#include "test_commons.h"
+#include "test_kokkos_3d_commons.h"
+
+#if DO_UNIT_TESTS_FOR_VIEW
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3D, Test3DTypesStride, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3D, Test3DConstTypesStride, );
+#endif
+
+#endif

--- a/tests/unit/test_kokkos_serialize_3d_stride.cc
+++ b/tests/unit/test_kokkos_serialize_3d_stride.cc
@@ -47,6 +47,7 @@
 #include "test_kokkos_3d_commons.h"
 
 #if DO_UNIT_TESTS_FOR_VIEW
+REGISTER_TYPED_TEST_CASE_P(KokkosViewTest3D, test_3d_any);
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S, KokkosViewTest3D, Test3DTypesStride, );
 INSTANTIATE_TYPED_TEST_CASE_P(test_3d_S_C, KokkosViewTest3D, Test3DConstTypesStride, );
 #endif

--- a/tests/unit/test_traversal.cc
+++ b/tests/unit/test_traversal.cc
@@ -99,8 +99,8 @@ private:
   TestObject2 obj2;
 };
 
-struct TestTraverse : checkpoint::Serializer {
-  TestTraverse() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+struct TestTraverse : checkpoint::BaseSerializer {
+  TestTraverse() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 
   void contiguousBytes(void* ptr, std::size_t size, std::size_t num_elms) {
     printf("size=%zu, num=%zu\n", size, num_elms);
@@ -139,13 +139,13 @@ struct CustomDispatch<SerializerT, std::vector<U>> {
   }
 };
 
-struct TestTraverse2 : checkpoint::Serializer {
+struct TestTraverse2 : checkpoint::BaseSerializer {
   template <typename U, typename V>
   using DispatcherType = CustomDispatch<U, V>;
 
   void contiguousBytes(void* ptr, std::size_t size, std::size_t num_elms) { }
 
-  TestTraverse2() : checkpoint::Serializer(checkpoint::eSerializationMode::None) { }
+  TestTraverse2() : checkpoint::BaseSerializer(checkpoint::eSerializationMode::None) { }
 };
 
 

--- a/tests/unit/test_variant_serializer.cc
+++ b/tests/unit/test_variant_serializer.cc
@@ -57,6 +57,11 @@ TEST_F(VariantTest, test_variant_basic) {
   std::variant<int, double> v;
   v = 10.0f;
 
+  static_assert(
+    checkpoint::SerializableTraits<decltype(v)>::is_bytecopyable,
+    "Must be byte copyable"
+  );
+
   auto ret = serialize(v);
   auto deser = deserialize<decltype(v)>(ret->getBuffer());
 
@@ -67,6 +72,11 @@ TEST_F(VariantTest, test_variant_basic) {
 TEST_F(VariantTest, test_variant_basic_string) {
   std::variant<int, double, std::string> v;
   v = "test";
+
+  static_assert(
+    not checkpoint::SerializableTraits<decltype(v)>::is_bytecopyable,
+    "Must not be byte copyable"
+  );
 
   auto ret = serialize(v);
   auto deser = deserialize<decltype(v)>(ret->getBuffer());
@@ -88,6 +98,11 @@ struct NotDefaultConstruct {
 TEST_F(VariantTest, test_variant_no_default_construct) {
   std::variant<int, double, NotDefaultConstruct, std::string> v;
   v = NotDefaultConstruct{10};
+
+  static_assert(
+    not checkpoint::SerializableTraits<decltype(v)>::is_bytecopyable,
+    "Must not be byte copyable"
+  );
 
   auto ret = serialize(v);
   auto deser = deserialize<decltype(v)>(ret->getBuffer());
@@ -112,6 +127,11 @@ struct NotCopyConstruct {
 TEST_F(VariantTest, test_variant_no_copy_construct) {
   std::variant<int, double, NotCopyConstruct, std::string> v;
   v.emplace<NotCopyConstruct>(10);
+
+  static_assert(
+    not checkpoint::SerializableTraits<decltype(v)>::is_bytecopyable,
+    "Must not be byte copyable"
+  );
 
   auto ret = serialize(v);
   auto deser = deserialize<decltype(v)>(ret->getBuffer());

--- a/tests/unit/test_variant_serializer.cc
+++ b/tests/unit/test_variant_serializer.cc
@@ -1,0 +1,123 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                          test_variant_serialize.cc
+//                           DARMA Toolkit v. 1.0.0
+//                 DARMA/checkpoint => Serialization Library
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+#include "test_harness.h"
+#include <checkpoint/checkpoint.h>
+
+#include <variant>
+#include <string>
+
+namespace checkpoint { namespace tests { namespace unit {
+
+using VariantTest = TestHarness;
+
+TEST_F(VariantTest, test_variant_basic) {
+  std::variant<int, double> v;
+  v = 10.0f;
+
+  auto ret = serialize(v);
+  auto deser = deserialize<decltype(v)>(ret->getBuffer());
+
+  EXPECT_EQ(deser->index(), 1);
+  EXPECT_EQ(std::get<double>(*deser), 10.0f);
+}
+
+TEST_F(VariantTest, test_variant_basic_string) {
+  std::variant<int, double, std::string> v;
+  v = "test";
+
+  auto ret = serialize(v);
+  auto deser = deserialize<decltype(v)>(ret->getBuffer());
+
+  EXPECT_EQ(deser->index(), 2);
+  EXPECT_EQ(std::get<std::string>(*deser), "test");
+}
+
+struct NotDefaultConstruct {
+  NotDefaultConstruct() = delete;
+  explicit NotDefaultConstruct(int a) : a_(a) { }
+  explicit NotDefaultConstruct(SERIALIZE_CONSTRUCT_TAG) { }
+  int a_ = 0;
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) { s | a_; }
+};
+
+TEST_F(VariantTest, test_variant_no_default_construct) {
+  std::variant<int, double, NotDefaultConstruct, std::string> v;
+  v = NotDefaultConstruct{10};
+
+  auto ret = serialize(v);
+  auto deser = deserialize<decltype(v)>(ret->getBuffer());
+
+  EXPECT_EQ(deser->index(), 2);
+  EXPECT_EQ(std::get<NotDefaultConstruct>(*deser).a_, 10);
+}
+
+struct NotCopyConstruct {
+  NotCopyConstruct() = delete;
+  explicit NotCopyConstruct(int a) : a_(a) { }
+  explicit NotCopyConstruct(SERIALIZE_CONSTRUCT_TAG) { }
+  NotCopyConstruct(NotCopyConstruct const&) = delete;
+  NotCopyConstruct(NotCopyConstruct&&) = default;
+  NotCopyConstruct& operator=(NotCopyConstruct&&) = default;
+  int a_ = 0;
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) { s | a_; }
+};
+
+TEST_F(VariantTest, test_variant_no_copy_construct) {
+  std::variant<int, double, NotCopyConstruct, std::string> v;
+  v.emplace<NotCopyConstruct>(10);
+
+  auto ret = serialize(v);
+  auto deser = deserialize<decltype(v)>(ret->getBuffer());
+
+  EXPECT_EQ(deser->index(), 2);
+  EXPECT_EQ(std::get<NotCopyConstruct>(*deser).a_, 10);
+}
+
+}}}


### PR DESCRIPTION
Fixes #274

This adds a serializer for std::variant. I've also included changes to rename `Serializer` to `BaseSerializer` after a very annoying bug in my code due to a mistake in my template. 

I've made changes that allow building the docker images with ARM so I can run/test on my M2 mac.