### PR TITLE
Drop `test_logical_device_view_contents`

### DIFF
--- a/tests/unit/test_kokkos_serialize_special.cc
+++ b/tests/unit/test_kokkos_serialize_special.cc
@@ -116,37 +116,6 @@ TEST_F(KokkosViewContentsTest, test_view_contents_2d_layout) {
   EXPECT_EQ(40, alias(1,1));
 }
 
-struct TestSpaceNamer {
-  static constexpr const char* get_name() { return "TestSpace"; }
-};
-
-using fake_memory_space = Kokkos::Experimental::LogicalMemorySpace<
-    Kokkos::HostSpace, Kokkos::DefaultHostExecutionSpace, TestSpaceNamer,
-    Kokkos::Experimental::LogicalSpaceSharesAccess::no_shared_access>;
-
-// Disable for now while view reconstruction logic is in flux
-#if 0
-TEST_F(KokkosViewContentsTest, test_logical_device_view_contents) {
-  // Create an inaccessible View
-  using LogicalViewType = Kokkos::View<int*, fake_memory_space>;
-  auto lv = LogicalViewType("lv", 1);
-
-  // Initialize a value
-  Kokkos::deep_copy(lv, 3);
-
-  auto ret = checkpoint::serialize<LogicalViewType>(lv);
-  auto out_view = checkpoint::deserialize<LogicalViewType>(ret->getBuffer());
-  auto const& out_view_ref = *out_view;
-
-  EXPECT_EQ(out_view_ref.extent(0), std::size_t(1));
-
-  auto mirror = create_mirror_view(out_view_ref);
-  Kokkos::deep_copy(mirror, out_view_ref);
-
-  EXPECT_EQ(mirror(0), 3);
-}
-#endif
-
 #if defined(KOKKOS_ENABLE_CUDA)
 
 TEST_F(KokkosViewContentsTest, test_cuda_device_view_contents) {


### PR DESCRIPTION
Fixes #324 

Since Kokkos::Experimental::LogicalMemorySpace was removed in kokkos/kokkos#6557

This will be released in Kokkos 4.3
This was discussed with @lifflander at SC23 and there was no objection to removing it.