### PR TITLE
#351: Update build against vt CI to fail properly

### DIFF
--- a/ci/build_against_vt.sh
+++ b/ci/build_against_vt.sh
@@ -95,10 +95,17 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       "${VT}"
-cmake_conf_ret="$?"
+# cmake_conf_ret="$?"
+
+# # Exit if configuration failed
+# if test "${cmake_conf_ret}" -ne 0
+# then
+#     echo "There was an error during CMake configuration"
+#     exit "${cmake_conf_ret}"
+# fi
 
 time cmake --build . --target "${target}"
-compilation_ret="$?"
+# compilation_ret="$?"
 
 if test "${use_ccache}"
 then
@@ -106,13 +113,9 @@ then
     ccache -s
 fi
 
-# Exit with error code if there was any
-if test "${cmake_conf_ret}" -ne 0
-then
-    echo "There was an error during CMake configuration"
-    exit "${cmake_conf_ret}"
-elif test "${compilation_ret}" -ne 0
-then
-    echo "There was an error during compilation"
-    exit "${compilation_ret}"
-fi
+# # Exit with error code if there was any
+# if test "${compilation_ret}" -ne 0
+# then
+#     echo "There was an error during compilation"
+#     exit "${compilation_ret}"
+# fi

--- a/ci/build_against_vt.sh
+++ b/ci/build_against_vt.sh
@@ -95,27 +95,10 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       "${VT}"
-# cmake_conf_ret="$?"
-
-# # Exit if configuration failed
-# if test "${cmake_conf_ret}" -ne 0
-# then
-#     echo "There was an error during CMake configuration"
-#     exit "${cmake_conf_ret}"
-# fi
-
 time cmake --build . --target "${target}"
-# compilation_ret="$?"
 
 if test "${use_ccache}"
 then
     { echo -e "===\n=== ccache statistics after build\n==="; } 2>/dev/null
     ccache -s
 fi
-
-# # Exit with error code if there was any
-# if test "${compilation_ret}" -ne 0
-# then
-#     echo "There was an error during compilation"
-#     exit "${compilation_ret}"
-# fi

--- a/ci/build_against_vt.sh
+++ b/ci/build_against_vt.sh
@@ -88,7 +88,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -DCMAKE_CXX_COMPILER="${CXX:-c++}" \
       -DCMAKE_C_COMPILER="${CC:-cc}" \
       -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS:-}" \
-      -Dcheckpoint_DIR="${CHECKPOINT_BUILD}/install" \
+      -Dcheckpoint_ROOT="${CHECKPOINT_BUILD}/install" \
       -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}" \
       -DCMAKE_INSTALL_PREFIX="${VT_BUILD}/install" \
       -Dvt_ci_build="${VT_CI_BUILD:-1}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
     volumes: *ubuntu-volumes
     command: &build-against-vt-cpp-command >
       /bin/bash -c "
-        /checkpoint/ci/build_against_vt.sh /vt /build /checkpoint
+        /checkpoint/ci/build_against_vt.sh /vt /build /checkpoint &&
         /vt/ci/test_cpp.sh /vt /build"
 
   ##############################################################################


### PR DESCRIPTION
Fixes #351 

This PR changes the parameter used for specifying path to `magistrate` in `ci/build_against_vt.sh` from `checkpoint_DIR` to `checkpoint_ROOT`.