### PR TITLE
#356: Fix backward compatibility with using `magistrate` via `add_subdirectory()` and wanting to use `vt::lib::checkpoint` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,9 @@ if (magistrate_ubsan_enabled)
   endif()
 endif()
 
-set(MAGISTRATE_LIBRARY checkpoint CACHE INTERNAL "" FORCE )
+set(MAGISTRATE_LIBRARY magistrate CACHE INTERNAL "" FORCE )
 set(MAGISTRATE_LIBRARY_NS vt::lib::magistrate "" CACHE INTERNAL "" FORCE )
+set(CHECKPOINT_LIBRARY_NS vt::lib::checkpoint "" CACHE INTERNAL "" FORCE )
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cmake/magistrateConfig.cmake.in
+++ b/cmake/magistrateConfig.cmake.in
@@ -4,7 +4,6 @@ get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(${SELF_DIR}/magistrateTargets.cmake)
 
 add_library(vt::lib::magistrate ALIAS vt::lib::checkpoint)
-# set(vt::lib::magistrate vt::lib::checkpoint)
 
 include(CMakeFindDependencyMacro)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(
 )
 set_property(TARGET ${MAGISTRATE_LIBRARY} PROPERTY EXPORT_NAME checkpoint)
 add_library(${MAGISTRATE_LIBRARY_NS} ALIAS ${MAGISTRATE_LIBRARY})
+add_library(${CHECKPOINT_LIBRARY_NS} ALIAS ${MAGISTRATE_LIBRARY})
 
 target_compile_features(${MAGISTRATE_LIBRARY} PUBLIC cxx_std_17)
 


### PR DESCRIPTION
Fixes #356 

When using `magistrate` via `find_package(magistrate)` following targets are visible:
- vt::lib::checkpoint (main exported target)
- vt::lib::magistrate (an alias created in magistrateConfig.cmake file)

When using `magistrate` via `find_package(checkpoint)` following targets are visible:
- vt::lib::checkpoint (main exported target)

When using `magistrate` via `add_subdirectory(checkpoint)` following targets are visible:
- magistrate (main target)
- vt::lib::magistrate (alias)
- vt::lib::checkpoint (alias)

