### PR TITLE
#360: fix documentation build unable to find `Doxyfile-mcss`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,6 +22,6 @@ jobs:
       TOKEN: ${{ secrets.GH_PAT }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker-compose run ubuntu-docs

--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -7,10 +7,9 @@ jobs:
     name: Check commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Fetch base_ref HEAD
         run: git fetch origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
       - name: Display base sha

--- a/.github/workflows/check-trailing-whitespace.yml
+++ b/.github/workflows/check-trailing-whitespace.yml
@@ -7,5 +7,5 @@ jobs:
     name: Find Trailing Whitespace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DARMA-tasking/find-trailing-whitespace@master

--- a/.github/workflows/dockerimage-clang-10-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-10-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-10-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-11-ubuntu-mpich-vt.yml
+++ b/.github/workflows/dockerimage-clang-11-ubuntu-mpich-vt.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-11-cache
       with:
@@ -47,11 +47,11 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.cache_ts.outputs.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: DARMA-tasking/vt
         ref: develop
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image

--- a/.github/workflows/dockerimage-clang-11-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-11-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-11-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-12-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-12-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-12-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-13-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-13-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-13-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-14-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-14-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-14-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-8-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-8-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-8-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-clang-9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-9-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-clang-9-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-gcc-10-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-10-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-gcc-10-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-gcc-8-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: ubuntu-gcc-9-cache
       with:
@@ -51,7 +51,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/dockerimage-nvcc-11-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-nvcc-11-ubuntu-mpich.yml
@@ -43,15 +43,15 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
-        cache-name: ubuntu-nvcc-11.2.0-cache
+        cache-name: ubuntu-nvcc-11.2.2-cache
       with:
         path: ${{ env.BUILD_ROOT }}/ccache
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -73,11 +73,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz

--- a/.github/workflows/pushdockerimage.yml
+++ b/.github/workflows/pushdockerimage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Docker Build & Push
         uses: jerray/publish-docker-action@master
         with:

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -60,7 +60,7 @@ then
     git clone "https://${token}@github.com/DARMA-tasking/DARMA-tasking.github.io"
     git clone https://github.com/mosra/m.css
     cd m.css
-    git checkout 6eefd92c2aa3e0a257503d31b1a469867dfff8b6
+    git checkout 5235066
     cd ../
     "$MCSS/documentation/doxygen.py" Doxyfile-mcss
     CKPT_NAME=checkpoint_docs

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -57,7 +57,7 @@ if test "${MAGISTRATE_DOXYGEN_ENABLED:-0}" -eq 1
 then
     MCSS=$PWD/m.css
     GHPAGE=$PWD/DARMA-tasking.github.io
-    git clone "https://${token}@github.com/DARMA-tasking/DARMA-tasking.github.io"
+    git clone --depth=1 "https://${token}@github.com/DARMA-tasking/DARMA-tasking.github.io"
     git clone https://github.com/mosra/m.css
     cd m.css
     git checkout 5235066

--- a/cmake/load_doxygen.cmake
+++ b/cmake/load_doxygen.cmake
@@ -1,4 +1,4 @@
-if (${checkpoint_doxygen_enabled})
+if (${magistrate_doxygen_enabled})
   find_package(Doxygen)
 
   if (DOXYGEN_FOUND)

--- a/scripts/workflow-template.yml
+++ b/scripts/workflow-template.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Prepare caching timestamp
       run: |
         echo "timestamp=$(TZ=UTC date +"%Y-%m-%d-%H;%M;%S")" >> $GITHUB_ENV
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       env:
         cache-name: [% cache_name %]
       with:
@@ -44,7 +44,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.timestamp }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare the base Docker image
@@ -66,11 +66,11 @@ jobs:
       run: |
         zip -j LastTest.log.gz ${{ env.BUILD_ROOT }}/checkpoint/Testing/Temporary/LastTest.log
         zip -j cmake-output.log.gz ${{ env.BUILD_ROOT }}/checkpoint/cmake-output.log
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake test output
         path: cmake-output.log.gz
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: CMake full output
         path: LastTest.log.gz


### PR DESCRIPTION
The actual fix for this issue is 02568cfb2bd3a830c05da019f4e962e9fe7948b4 (the option in `load_doxygen.cmake` was not updated).

Some small cleanup along the way:
- update GitHub actions to get rid of deprecation warnings
- update `m.css` library to the latest version
- optimize cloning of the required repositories (limit depth to 1)

fixes #360 