### PR TITLE
#344 Implement checkpoint::is_footprinter<>

### DIFF
--- a/src/checkpoint/container/atomic_serialize.h
+++ b/src/checkpoint/container/atomic_serialize.h
@@ -54,7 +54,7 @@ template <
   typename SerializerT,
   typename T,
   typename = std::enable_if_t<
-    std::is_same<SerializerT, checkpoint::Footprinter>::value
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serialize(SerializerT& s, const std::atomic<T>& atomic) {

--- a/src/checkpoint/container/function_serialize.h
+++ b/src/checkpoint/container/function_serialize.h
@@ -68,10 +68,7 @@ template <
   typename Res,
   typename... ArgTypes,
   typename = std::enable_if_t<
-    std::is_same<
-      SerializerT,
-      checkpoint::Footprinter
-    >::value
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serializeFunction(SerializerT& s, std::function<Res(ArgTypes...)>& fn) {

--- a/src/checkpoint/container/kokkos_unordered_map_serialize.h
+++ b/src/checkpoint/container/kokkos_unordered_map_serialize.h
@@ -117,7 +117,7 @@ template <
   typename Hasher, typename EqualTo
 >
 typename std::enable_if_t<
-  not std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  not checkpoint::is_footprinter_v<SerializerT>, void
 > serialize(
   SerializerT& s,
   Kokkos::UnorderedMap<Key, Value, Device, Hasher, EqualTo>& map
@@ -140,7 +140,7 @@ template <
   typename Hasher, typename EqualTo
 >
 typename std::enable_if_t<
-  std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  checkpoint::is_footprinter_v<SerializerT>, void
 > serialize(
   SerializerT& s,
   Kokkos::UnorderedMap<Key, Value, Device, Hasher, EqualTo>& map

--- a/src/checkpoint/container/list_serialize.h
+++ b/src/checkpoint/container/list_serialize.h
@@ -56,7 +56,7 @@ namespace checkpoint {
 
 template <typename Serializer, typename ContainerT, typename ElmT>
 inline typename std::enable_if_t<
-  not std::is_same<Serializer, checkpoint::Footprinter>::value, void
+  not checkpoint::is_footprinter_v<Serializer>, void
 >
 deserializeOrderedElems(
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size,
@@ -76,7 +76,7 @@ deserializeOrderedElems(
 
 template <typename Serializer, typename ContainerT, typename ElmT>
 inline typename std::enable_if_t<
-  not std::is_same<Serializer, checkpoint::Footprinter>::value, void
+  not checkpoint::is_footprinter_v<Serializer>, void
 >
 deserializeOrderedElems(
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size,
@@ -96,7 +96,7 @@ deserializeOrderedElems(
 
 template <typename Serializer, typename ContainerT, typename ElmT>
 inline typename std::enable_if_t<
-  std::is_same<Serializer, checkpoint::Footprinter>::value, void
+  checkpoint::is_footprinter_v<Serializer>, void
 >
 deserializeOrderedElems(
   Serializer&, ContainerT&, typename ContainerT::size_type

--- a/src/checkpoint/container/map_serialize.h
+++ b/src/checkpoint/container/map_serialize.h
@@ -58,7 +58,7 @@ namespace checkpoint {
 
 template <typename Serializer, typename ContainerT, typename ElmT>
 inline typename std::enable_if_t<
-  not std::is_same<Serializer, checkpoint::Footprinter>::value,
+  not checkpoint::is_footprinter_v<Serializer>,
   void
 > deserializeEmplaceElems(
   Serializer& s, ContainerT& cont, typename ContainerT::size_type size
@@ -77,7 +77,7 @@ inline typename std::enable_if_t<
 
 template <typename Serializer, typename ContainerT, typename ElmT>
 inline typename std::enable_if_t<
-  std::is_same<Serializer, checkpoint::Footprinter>::value,
+  checkpoint::is_footprinter_v<Serializer>,
   void
 > deserializeEmplaceElems(
   Serializer&, ContainerT&, typename ContainerT::size_type

--- a/src/checkpoint/container/queue_serialize.h
+++ b/src/checkpoint/container/queue_serialize.h
@@ -108,7 +108,7 @@ template <
   typename SerializerT,
   typename Q,
   typename = std::enable_if_t<
-    std::is_same_v<SerializerT, checkpoint::Footprinter>
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serializeQueueLikeContainer(SerializerT& s, const Q& q) {

--- a/src/checkpoint/container/raw_ptr_serialize.h
+++ b/src/checkpoint/container/raw_ptr_serialize.h
@@ -61,10 +61,7 @@ template <
   typename SerializerT,
   typename T,
   typename = std::enable_if_t<
-    std::is_same<
-      SerializerT,
-      checkpoint::Footprinter
-    >::value
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serialize(SerializerT& s, T* ptr) {
@@ -95,7 +92,7 @@ void serializeRawPtr(SerializerT& s, void* ptr) {
 #define CHECKPOINT_FOOTPRINT_PIMPL_WITH_SIZEOF_PTR(PIMPL_TYPE) \
   template < \
     typename SerializerT, \
-    typename = std::enable_if_t< std::is_same<SerializerT, checkpoint::Footprinter >::value > \
+    typename = std::enable_if_t< checkpoint::is_footprinter_v<SerializerT> > \
   > \
   void serialize(SerializerT &s, PIMPL_TYPE *t) { \
     s.countBytes(t); \

--- a/src/checkpoint/container/shared_ptr_serialize.h
+++ b/src/checkpoint/container/shared_ptr_serialize.h
@@ -52,10 +52,7 @@ template <
   typename SerializerT,
   typename T,
   typename = std::enable_if_t<
-    std::is_same<
-      SerializerT,
-      checkpoint::Footprinter
-    >::value
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serialize(SerializerT& s, std::shared_ptr<T>& ptr) {

--- a/src/checkpoint/container/thread_serialize.h
+++ b/src/checkpoint/container/thread_serialize.h
@@ -53,7 +53,7 @@ namespace checkpoint {
 template <
   typename SerializerT,
   typename = std::enable_if_t<
-    std::is_same<SerializerT, checkpoint::Footprinter>::value
+    checkpoint::is_footprinter_v<SerializerT>
   >
 >
 void serialize(SerializerT& s, const std::thread& t) {

--- a/src/checkpoint/container/vector_serialize.h
+++ b/src/checkpoint/container/vector_serialize.h
@@ -56,7 +56,7 @@ namespace checkpoint {
 
 template <typename SerializerT, typename T, typename VectorAllocator>
 typename std::enable_if_t<
-  not std::is_same<SerializerT, checkpoint::Footprinter>::value, SerialSizeType
+  not checkpoint::is_footprinter_v<SerializerT>, SerialSizeType
 >
 serializeVectorMeta(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
   SerialSizeType vec_capacity = vec.capacity();
@@ -108,7 +108,7 @@ void constructVectorData(
 
 template <typename SerializerT, typename T, typename VectorAllocator>
 typename std::enable_if_t<
-  not std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  not checkpoint::is_footprinter_v<SerializerT>, void
 >
 serialize(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
   auto const vec_size = serializeVectorMeta(s, vec);
@@ -122,7 +122,7 @@ serialize(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
 
 template <typename SerializerT, typename VectorAllocator>
 typename std::enable_if_t<
-  not std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  not checkpoint::is_footprinter_v<SerializerT>, void
 >
 serialize(SerializerT& s, std::vector<bool, VectorAllocator>& vec) {
   auto const vec_size = serializeVectorMeta(s, vec);
@@ -146,7 +146,7 @@ serialize(SerializerT& s, std::vector<bool, VectorAllocator>& vec) {
 
 template <typename SerializerT, typename T, typename VectorAllocator>
 typename std::enable_if_t<
-  std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  checkpoint::is_footprinter_v<SerializerT>, void
 >
 serialize(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
   s.countBytes(vec);
@@ -156,7 +156,7 @@ serialize(SerializerT& s, std::vector<T, VectorAllocator>& vec) {
 
 template <typename SerializerT, typename VectorAllocator>
 typename std::enable_if_t<
-  std::is_same<SerializerT, checkpoint::Footprinter>::value, void
+  checkpoint::is_footprinter_v<SerializerT>, void
 >
 serialize(SerializerT& s, std::vector<bool, VectorAllocator>& vec) {
   s.countBytes(vec);

--- a/src/checkpoint/serializers/footprinter.h
+++ b/src/checkpoint/serializers/footprinter.h
@@ -72,6 +72,20 @@ private:
   SerialSizeType num_bytes_ = 0;
 };
 
+namespace {
+    template <typename>
+    struct is_footprinter_impl : public std::false_type {};
+
+    template <>
+    struct is_footprinter_impl<Footprinter> : public std::true_type {};
+}
+
+template<typename U>
+using is_footprinter = is_footprinter_impl<std::decay_t<U>>;
+
+template<typename U>
+static constexpr const bool is_footprinter_v = is_footprinter<U>::value;
+
 } /* end namespace checkpoint */
 
 #endif /*INCLUDED_SRC_CHECKPOINT_SERIALIZERS_FOOTPRINTER_H*/

--- a/tests/unit/test_footprinter.cc
+++ b/tests/unit/test_footprinter.cc
@@ -105,10 +105,7 @@ struct TestDerived2 : TestBase {
   template <
     typename SerializerT,
     typename = std::enable_if_t<
-      std::is_same<
-        SerializerT,
-        checkpoint::Footprinter
-      >::value
+      checkpoint::is_footprinter_v<SerializerT>
     >
   >
   void serialize(SerializerT& s) {


### PR DESCRIPTION
Required for #344 as a pre-step to PR #345, this implements the is_footprinter helper so we can begin using it in VT prior to it being required.