### PR TITLE
#376: rename virtual serialize macros

### DIFF
--- a/docs/shared/checkpoint_learn_serialize.md
+++ b/docs/shared/checkpoint_learn_serialize.md
@@ -82,8 +82,8 @@ serialization of the class state.
 
 To serialize polymorphic class hierarchies, one must write serializers for each
 class in the hierarchy. Then, the user should either insert macros
-`checkpoint_virtual_serialize_root()` and
-`checkpoint_virtual_serialize_derived_from(T)` to inform *magistrate* of the
+`magistrate_virtual_serialize_root()` and
+`magistrate_virtual_serialize_derived_from(T)` to inform *magistrate* of the
 hierarchy so it can automatically traverse the hierarchy. Alternatively, the
 user may use the inheritance wrappers `magistrate::SerializableBase<T>` and
 `magistrate::SerializableDerived<T, U>` to achieve the same effect.

--- a/examples/checkpoint_example_polymorphic_macro.cc
+++ b/examples/checkpoint_example_polymorphic_macro.cc
@@ -57,7 +57,7 @@ struct MyBase {
   virtual ~MyBase() = default;
 
   // Add serializing macro
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   int val_ = 0;
 
@@ -76,7 +76,7 @@ struct MyObj : public MyBase {
   explicit MyObj(::magistrate::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   template <typename SerializerT>
   void serialize(SerializerT&) {
@@ -94,7 +94,7 @@ struct MyObj2 : public MyBase {
   explicit MyObj2(::magistrate::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   template <typename SerializerT>
   void serialize(SerializerT&) {
@@ -114,7 +114,7 @@ struct MyObj3 : public MyBase {
   explicit MyObj3(::magistrate::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {

--- a/examples/checkpoint_example_polymorphic_macro_nonintrusive.cc
+++ b/examples/checkpoint_example_polymorphic_macro_nonintrusive.cc
@@ -58,7 +58,7 @@ struct MyBase {
   virtual ~MyBase() = default;
 
   // Add serializing macro
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   int val_ = 0;
 
@@ -71,7 +71,7 @@ struct MyObj : public MyBase {
   explicit MyObj(::checkpoint::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   void test() override {
     printf("test MyObj 10 == %d ?\n", val_);
@@ -84,7 +84,7 @@ struct MyObj2 : public MyBase {
   explicit MyObj2(::checkpoint::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   void test() override {
     printf("test MyObj2 20 == %d ?\n", val_);
@@ -100,7 +100,7 @@ struct MyObj3 : public MyBase {
   explicit MyObj3(::checkpoint::SERIALIZE_CONSTRUCT_TAG) {}
 
   // Add macro for serialization
-  checkpoint_virtual_serialize_derived_from(MyBase)
+  magistrate_virtual_serialize_derived_from(MyBase)
 
   void test() override {
     printf("val_ 30  a 10 b 20 c 100 = %d %d %d %d\n", val_, a, b, c);

--- a/src/checkpoint/dispatch/dispatch_virtual.h
+++ b/src/checkpoint/dispatch/dispatch_virtual.h
@@ -68,8 +68,8 @@
  *
  *   - Insert checkpoint macros in your virtual class hierarchy for derived and
  *     base classes with the corresponding macros:
- *     - \c checkpoint_virtual_serialize_root()
- *     - \c checkpoint_virtual_serialize_derived_from(ParentT)
+ *     - \c magistrate_virtual_serialize_root()
+ *     - \c magistrate_virtual_serialize_derived_from(ParentT)
  *
  * --------------------------- Invocation ------------------------------------
  *

--- a/src/checkpoint/dispatch/vrt/base.h
+++ b/src/checkpoint/dispatch/vrt/base.h
@@ -50,7 +50,17 @@
 #include "checkpoint/dispatch/vrt/inheritance_assert_helpers.h"
 #include "checkpoint/dispatch/vrt/serialize_instantiator.h"
 
-#define checkpoint_virtual_serialize_root()                                                      \
+[[deprecated("checkpoint_virtual_serialize_root is deprecated,"
+             " please use magistrate_virtual_serialize_root")]]
+constexpr bool checkpoint_virtual_serialize_root_is_deprecated() {
+  return true;
+}
+
+#define checkpoint_virtual_serialize_root                           \
+  static_assert(checkpoint_virtual_serialize_root_is_deprecated()); \
+  magistrate_virtual_serialize_root
+
+#define magistrate_virtual_serialize_root()                                                      \
   auto _CheckpointVSBaseTypeFn() -> decltype(auto) { return this; }                              \
   virtual void _checkpointDynamicSerialize(                                                      \
     void* s,                                                                                     \
@@ -74,7 +84,17 @@
     return ::checkpoint::dispatch::vrt::objregistry::makeObjIdx<_CheckpointBaseType>();          \
   }
 
-#define checkpoint_virtual_serialize_base(BASE) checkpoint_virtual_serialize_root()
+[[deprecated("checkpoint_virtual_serialize_base is deprecated,"
+             " please use magistrate_virtual_serialize_base")]]
+constexpr bool checkpoint_virtual_serialize_base_is_deprecated() {
+  return true;
+}
+
+#define checkpoint_virtual_serialize_base                           \
+  static_assert(checkpoint_virtual_serialize_base_is_deprecated()); \
+  magistrate_virtual_serialize_base
+
+#define magistrate_virtual_serialize_base(BASE) magistrate_virtual_serialize_root()
 
 namespace checkpoint { namespace dispatch { namespace vrt {
 
@@ -86,7 +106,7 @@ namespace checkpoint { namespace dispatch { namespace vrt {
  */
 template <typename BaseT>
 struct SerializableBase {
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~SerializableBase() {}
 };

--- a/src/checkpoint/dispatch/vrt/derived.h
+++ b/src/checkpoint/dispatch/vrt/derived.h
@@ -50,7 +50,17 @@
 #include "checkpoint/dispatch/vrt/inheritance_assert_helpers.h"
 #include "checkpoint/dispatch/vrt/serialize_instantiator.h"
 
-#define checkpoint_virtual_serialize_derived_from(PARENT)                                   \
+[[deprecated("checkpoint_virtual_serialize_derived_from is deprecated,"
+             " please use magistrate_virtual_serialize_derived_from")]]
+constexpr bool checkpoint_virtual_serialize_derived_from_is_deprecated() {
+  return true;
+}
+
+#define checkpoint_virtual_serialize_derived_from                           \
+  static_assert(checkpoint_virtual_serialize_derived_from_is_deprecated()); \
+  magistrate_virtual_serialize_derived_from
+
+#define magistrate_virtual_serialize_derived_from(PARENT)                                   \
   void _checkpointDynamicSerialize(                                                         \
     void* s,                                                                                \
     ::checkpoint::dispatch::vrt::TypeIdx base_ser_idx,                                      \
@@ -85,7 +95,17 @@
     return ::checkpoint::dispatch::vrt::objregistry::makeObjIdx<_CheckpointDerivedType>();  \
   }
 
-#define checkpoint_virtual_serialize_derived(DERIVED, PARENT) checkpoint_virtual_serialize_derived_from(PARENT)
+[[deprecated("checkpoint_virtual_serialize_derived is deprecated,"
+             " please use magistrate_virtual_serialize_derived")]]
+constexpr bool checkpoint_virtual_serialize_derived_is_deprecated() {
+  return true;
+}
+
+#define checkpoint_virtual_serialize_derived                           \
+  static_assert(checkpoint_virtual_serialize_derived_is_deprecated()); \
+  magistrate_virtual_serialize_derived
+
+#define magistrate_virtual_serialize_derived(DERIVED, PARENT) magistrate_virtual_serialize_derived_from(PARENT)
 
 namespace checkpoint { namespace dispatch { namespace vrt {
 
@@ -124,7 +144,7 @@ struct SerializableDerived : BaseT {
 
   SerializableDerived() = default;
 
-  checkpoint_virtual_serialize_derived(DerivedT, BaseT)
+  magistrate_virtual_serialize_derived(DerivedT, BaseT)
 };
 
 }}} /* end namespace checkpoint::dispatch::vrt */

--- a/src/checkpoint/dispatch/vrt/inheritance_assert_helpers.h
+++ b/src/checkpoint/dispatch/vrt/inheritance_assert_helpers.h
@@ -60,7 +60,7 @@ inline void assertTypeIdxMatch(TypeIdx const expected_idx) {
     "\" does not matched expected value. "
     "You are probably missing a SerializableBase<T> or SerializableDerived<T> "
     "in the virtual class hierarchy; or, if you are using macros: "
-    "checkpoint_virtual_serialize_root() or checkpoint_virtual_serialize_derived_from(..)";
+    "magistrate_virtual_serialize_root() or magistrate_virtual_serialize_derived_from(..)";
   checkpointAssert(
     obj_idx == expected_idx or expected_idx == no_type_idx, debug_str.c_str()
   );

--- a/tests/unit/test_footprinter.cc
+++ b/tests/unit/test_footprinter.cc
@@ -83,7 +83,7 @@ void serialize(Serializer& s, Test2 t) {
 
 struct TestBase {
 
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~TestBase() = default;
 
@@ -100,7 +100,7 @@ struct TestDerived2 : TestBase {
   explicit TestDerived2(int) {}
   explicit TestDerived2(SERIALIZE_CONSTRUCT_TAG) {}
 
-  checkpoint_virtual_serialize_derived_from(TestBase)
+  magistrate_virtual_serialize_derived_from(TestBase)
 
   template <
     typename SerializerT,

--- a/tests/unit/test_serialization_error_checking.cc
+++ b/tests/unit/test_serialization_error_checking.cc
@@ -115,7 +115,7 @@ TEST_F(TestObject, test_serialization_error_checking) {
 }
 
 struct Base {
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~Base() = default;
 
@@ -128,7 +128,7 @@ struct Base {
 };
 
 struct Derived : public Base {
-  checkpoint_virtual_serialize_derived_from(Base)
+  magistrate_virtual_serialize_derived_from(Base)
 
   int dd{4};
 

--- a/tests/unit/test_virtual_serialize.cc
+++ b/tests/unit/test_virtual_serialize.cc
@@ -215,7 +215,7 @@ struct TestBase {
   explicit TestBase(TEST_CONSTRUCT) { init();  }
   explicit TestBase(SERIALIZE_CONSTRUCT_TAG) {}
 
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~TestBase() = default;
 
@@ -245,7 +245,7 @@ struct TestDerived1 : TestBase {
   explicit TestDerived1(TEST_CONSTRUCT tag) : Parent(tag) { init();  }
   explicit TestDerived1(SERIALIZE_CONSTRUCT_TAG tag) : Parent(tag)  {}
 
-  checkpoint_virtual_serialize_derived_from(TestBase)
+  magistrate_virtual_serialize_derived_from(TestBase)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -278,7 +278,7 @@ struct TestDerived2 : TestBase {
   explicit TestDerived2(TEST_CONSTRUCT tag) : Parent(tag) { init();  }
   explicit TestDerived2(SERIALIZE_CONSTRUCT_TAG tag) : Parent(tag) {}
 
-  checkpoint_virtual_serialize_derived_from(TestBase)
+  magistrate_virtual_serialize_derived_from(TestBase)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -312,7 +312,7 @@ struct TestDerived3 : TestDerived2 {
   explicit TestDerived3(TEST_CONSTRUCT tag) : Parent(tag) { init();  }
   explicit TestDerived3(SERIALIZE_CONSTRUCT_TAG tag) : Parent(tag) {}
 
-  checkpoint_virtual_serialize_derived_from(TestDerived2)
+  magistrate_virtual_serialize_derived_from(TestDerived2)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -424,7 +424,7 @@ struct TestBase {
   explicit TestBase(TEST_CONSTRUCT) { init();  }
   explicit TestBase(SERIALIZE_CONSTRUCT_TAG) {}
 
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~TestBase() = default;
 
@@ -454,7 +454,7 @@ struct TestDerived1 : TestBase {
   explicit TestDerived1(TEST_CONSTRUCT tag) : Parent(tag) { init();  }
   explicit TestDerived1(SERIALIZE_CONSTRUCT_TAG tag) : Parent(tag)  {}
 
-  checkpoint_virtual_serialize_derived_from(Parent)
+  magistrate_virtual_serialize_derived_from(Parent)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -499,7 +499,7 @@ struct TestDerived2 : TestBase {
   explicit TestDerived2(TEST_CONSTRUCT tag) : Parent(tag) { init();  }
   explicit TestDerived2(SERIALIZE_CONSTRUCT_TAG tag) : Parent(tag) {}
 
-  checkpoint_virtual_serialize_derived_from(Parent)
+  magistrate_virtual_serialize_derived_from(Parent)
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -620,7 +620,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(
 using TestVirtualSerializeTemplated = TestHarness;
 
 struct HolderBase {
-  checkpoint_virtual_serialize_root()
+  magistrate_virtual_serialize_root()
 
   virtual ~HolderBase() = default;
 
@@ -630,7 +630,7 @@ struct HolderBase {
 
 template <typename ObjT>
 struct HolderObjBase : HolderBase {
-  checkpoint_virtual_serialize_derived_from(HolderBase)
+  magistrate_virtual_serialize_derived_from(HolderBase)
 
   virtual ObjT* get() = 0;
 
@@ -640,7 +640,7 @@ struct HolderObjBase : HolderBase {
 
 template <typename ObjT>
 struct HolderBasic final : HolderObjBase<ObjT> {
-  checkpoint_virtual_serialize_derived_from(HolderObjBase<ObjT>)
+  magistrate_virtual_serialize_derived_from(HolderObjBase<ObjT>)
 
   ObjT* get() override { return obj_.get(); }
   std::unique_ptr<ObjT> obj_ = nullptr;


### PR DESCRIPTION
fixes #376 

Adds `magistrate_` version of the macros and deprecates the old `checkpoint_` ones.

Since it's impossible to deprecate a macro on its own, I am using a helper (constexpr) function + a static_assert combo to generate warnings. You can see `gtest` doing a similiar thing [here](https://github.com/google/googletest/blob/35d0c365609296fa4730d62057c487e3cfa030ff/googletest/include/gtest/internal/gtest-internal.h#L1242-L1252).